### PR TITLE
Upload indicator for imports

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -185,6 +185,17 @@ module.exports = {
                     // in development "style" loader enables hot editing of CSS.
                     {
                         test: /\.css$/,
+                        include: /node_modules/,
+                        use: [
+                            require.resolve('style-loader'),
+                            {
+                                loader: require.resolve('css-loader'),
+                            },
+                        ],
+                    },
+                    {
+                        test: /\.css$/,
+                        exclude: /node_modules/,
                         use: [
                             require.resolve('style-loader'),
                             {

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -175,6 +175,36 @@ module.exports = {
                     // in the main CSS file.
                     {
                         test: /\.css$/,
+                        include: /node_modules/,
+                        loader: ExtractTextPlugin.extract(
+                            Object.assign(
+                                {
+                                    fallback: {
+                                        loader: require.resolve('style-loader'),
+                                        options: {
+                                            hmr: false,
+                                        },
+                                    },
+                                    use: [
+                                        {
+                                            loader: require.resolve(
+                                                'css-loader'
+                                            ),
+                                            options: {
+                                                minimize: true,
+                                                sourceMap: shouldUseSourceMap,
+                                            },
+                                        },
+                                    ],
+                                },
+                                extractTextPluginOptions
+                            )
+                        ),
+                        // Note: this won't work without `new ExtractTextPlugin()` in `plugins`.
+                    },
+                    {
+                        test: /\.css$/,
+                        exclude: /node_modules/,
                         loader: ExtractTextPlugin.extract(
                             Object.assign(
                                 {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@dhis2/d2-i18n-extract": "^1.0.6",
     "@dhis2/d2-i18n-generate": "^1.0.18",
     "@dhis2/d2-ui-header-bar": "^1.0.11",
+    "@dhis2/ui": "^1.0.0-beta.9",
     "autoprefixer": "7.1.6",
     "axios": "^0.18.0",
     "babel-core": "6.26.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "npm run extract-pot && npm run format && CI=true npm run test && git add ./i18n/"
+      "pre-commit": "npm run extract-pot && npm run format && git add ./i18n/"
     }
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@dhis2/d2-i18n-extract": "^1.0.6",
     "@dhis2/d2-i18n-generate": "^1.0.18",
     "@dhis2/d2-ui-header-bar": "^1.0.11",
-    "@dhis2/ui": "^1.0.0-beta.9",
+    "@dhis2/ui": "^1.0.0-beta.10",
     "autoprefixer": "7.1.6",
     "axios": "^0.18.0",
     "babel-core": "6.26.0",

--- a/src/App.js
+++ b/src/App.js
@@ -11,6 +11,7 @@ import Template from 'pages/Template'
 
 import * as pages from './pages'
 import { Route, withRouter } from 'react-router-dom'
+import { Progress } from './components'
 
 config.i18n.strings.add('settings')
 config.i18n.strings.add('profile')
@@ -96,6 +97,7 @@ class App extends React.Component {
 
         return (
             <Template>
+                <Progress />
                 {Object.keys(pages).map(k => {
                     const page = pages[k]
                     return (

--- a/src/App.js
+++ b/src/App.js
@@ -11,7 +11,6 @@ import Template from 'pages/Template'
 
 import * as pages from './pages'
 import { Route, withRouter } from 'react-router-dom'
-import { Progress } from './components'
 
 config.i18n.strings.add('settings')
 config.i18n.strings.add('profile')
@@ -97,7 +96,6 @@ class App extends React.Component {
 
         return (
             <Template>
-                <Progress />
                 {Object.keys(pages).map(k => {
                     const page = pages[k]
                     return (

--- a/src/components/FormBase/index.js
+++ b/src/components/FormBase/index.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import { getFieldState, getFieldValue } from 'helpers'
-import { Form, Loading, Error } from 'components'
-
+import { Form, Loading, Error, Progress } from 'components'
 import s from './styles.css'
 
 export class FormBase extends React.Component {
@@ -19,11 +18,13 @@ export class FormBase extends React.Component {
 
     getFormState() {
         const values = {}
-        this.fields.map(f => f.name).forEach(name => {
-            if (name) {
-                values[name] = getFieldValue(this.state[name])
-            }
-        })
+        this.fields
+            .map(f => f.name)
+            .forEach(name => {
+                if (name) {
+                    values[name] = getFieldValue(this.state[name])
+                }
+            })
         return values
     }
 
@@ -46,7 +47,7 @@ export class FormBase extends React.Component {
         }
 
         if (this.state.processing) {
-            return <Loading />
+            return <Progress />
         }
 
         return (

--- a/src/components/FormBase/index.js
+++ b/src/components/FormBase/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { getFieldState, getFieldValue } from 'helpers'
-import { Form, Loading, Error, Progress } from 'components'
+import { Form, Error, Progress } from 'components'
 import s from './styles.css'
 
 export class FormBase extends React.Component {

--- a/src/components/Loading/Progress.js
+++ b/src/components/Loading/Progress.js
@@ -22,7 +22,11 @@ export class Progress extends Component {
         })
 
     render() {
-        return <LinearProgress amount={50} margin={'100px'} />
+        return (
+            <div className={s.container}>
+                <LinearProgress amount={this.state.progress} margin={'100px'} />
+            </div>
+        )
     }
 }
 

--- a/src/components/Loading/Progress.js
+++ b/src/components/Loading/Progress.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import { eventEmitter } from 'services'
-import { LinearProgress } from '@dhis2/ui/core'
+import LinearProgress from '@dhis2/ui/core/LinearProgress'
 import s from './styles.css'
 
 export class Progress extends Component {

--- a/src/components/Loading/Progress.js
+++ b/src/components/Loading/Progress.js
@@ -1,0 +1,29 @@
+import React, { Component } from 'react'
+import { eventEmitter } from 'services'
+import { LinearProgress } from '@dhis2/ui/core'
+import s from './styles.css'
+
+export class Progress extends Component {
+    state = {
+        progress: 0,
+    }
+
+    componentDidMount() {
+        eventEmitter.on('upload.progress', this.onProgress)
+    }
+
+    componentWillUnMount() {
+        eventEmitter.off('upload.progress', this.onProgress)
+    }
+
+    onProgress = stats =>
+        this.setState({
+            progress: stats.percentComplete,
+        })
+
+    render() {
+        return <LinearProgress amount={50} margin={'100px'} />
+    }
+}
+
+export default Progress

--- a/src/components/Loading/index.js
+++ b/src/components/Loading/index.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { CircularProgress } from 'material-ui'
 import s from './styles.css'
+import Progress from './Progress'
 
 export function Loading({ size, thickness }) {
     return (
@@ -9,3 +10,5 @@ export function Loading({ size, thickness }) {
         </div>
     )
 }
+
+export { Progress }

--- a/src/components/Loading/styles.css
+++ b/src/components/Loading/styles.css
@@ -3,7 +3,7 @@
     flex-direction: row;
     align-items: center;
     justify-content: center;
-    width: 100%;
-    margin: 50px 0;
+    width: 800px;
+    margin: 60px auto;
     text-align: center;
 }

--- a/src/helpers/xhr.js
+++ b/src/helpers/xhr.js
@@ -15,7 +15,7 @@ export function getUploadXHR(url, upload, type, onResponse, onError) {
     )
 
     xhr.onreadystatechange = onReadyStateChange(xhr, type, onResponse, onError)
-
+    xhr.upload.onprogress = onProgress
     return xhr
 }
 
@@ -38,5 +38,14 @@ export function onReadyStateChange(xhr, type, onResponse, onError) {
         } else if ([3, 4, 5].includes(status)) {
             onError(e)
         }
+    }
+}
+
+export function onProgress(evt) {
+    if (evt.lengthComputable) {
+        const percentComplete = parseInt((evt.loaded / evt.total) * 100)
+        const stats = { ...evt, percentComplete }
+        console.log('upload', stats)
+        eventEmitter.emit('upload.progress', stats)
     }
 }

--- a/src/helpers/xhr.js
+++ b/src/helpers/xhr.js
@@ -45,7 +45,6 @@ export function onProgress(evt) {
     if (evt.lengthComputable) {
         const percentComplete = parseInt((evt.loaded / evt.total) * 100)
         const stats = { ...evt, percentComplete }
-        console.log('upload', stats)
         eventEmitter.emit('upload.progress', stats)
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -294,10 +294,10 @@
     material-ui-icons "^1.0.0-beta.36"
     rxjs "^5.5.7"
 
-"@dhis2/ui@^1.0.0-beta.9":
-  version "1.0.0-beta.9"
-  resolved "https://registry.yarnpkg.com/@dhis2/ui/-/ui-1.0.0-beta.9.tgz#767ec6bde58ea3efabfe6d2c2136a8c593022116"
-  integrity sha512-HgXL44YZHaJbWjU5ppmdsm7m562pkQku6XpQsWq/oCBghDGPcFCDNkcRkEpb2ERpJdnujWKfTHzda7uD1ej+fw==
+"@dhis2/ui@^1.0.0-beta.10":
+  version "1.0.0-beta.10"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui/-/ui-1.0.0-beta.10.tgz#ad683f6823121cb8f1c8d81cde62fb4fd22bf015"
+  integrity sha512-kKsoG4zx6bCICYhwgbKz0g3FWlEtMVgpZaoJtQwD2Y86tPSxcUaSTYyDOVLUCepjyMj+B9xxCtt0nSvXV5rUBA==
   dependencies:
     classnames "^2.2.6"
     material-design-icons-iconfont "^4.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -294,6 +294,15 @@
     material-ui-icons "^1.0.0-beta.36"
     rxjs "^5.5.7"
 
+"@dhis2/ui@^1.0.0-beta.9":
+  version "1.0.0-beta.9"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui/-/ui-1.0.0-beta.9.tgz#767ec6bde58ea3efabfe6d2c2136a8c593022116"
+  integrity sha512-HgXL44YZHaJbWjU5ppmdsm7m562pkQku6XpQsWq/oCBghDGPcFCDNkcRkEpb2ERpJdnujWKfTHzda7uD1ej+fw==
+  dependencies:
+    classnames "^2.2.6"
+    material-design-icons-iconfont "^4.0.2"
+    typeface-roboto "^0.0.54"
+
 "@marionebl/sander@^0.6.0":
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/@marionebl/sander/-/sander-0.6.1.tgz#1958965874f24bc51be48875feb50d642fc41f7b"
@@ -2274,6 +2283,11 @@ classnames@^2.2.5:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
   integrity sha1-+zgB1FNGdknvNgPH1hoCvRKb3m0=
+
+classnames@^2.2.6:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
+  integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
 
 clean-css@4.1.x:
   version "4.1.11"
@@ -7557,6 +7571,11 @@ marked@~0.3.6:
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.19.tgz#5d47f709c4c9fc3c216b6d46127280f40b39d790"
   integrity sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==
 
+material-design-icons-iconfont@^4.0.2:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/material-design-icons-iconfont/-/material-design-icons-iconfont-4.0.4.tgz#8f1eb68bd59a42944209907bfd1eb997405bf162"
+  integrity sha512-jz4P9uLPrbEbzhEsEKuN+5N1TgBFdc4Dslzx/wc22D7FKT/Aelgs/HP8mB3LGI893NND5Rw6xpvZoiXtukB5zw==
+
 material-ui-icons@^1.0.0-beta.36:
   version "1.0.0-beta.36"
   resolved "https://registry.yarnpkg.com/material-ui-icons/-/material-ui-icons-1.0.0-beta.36.tgz#86390a61f4c83f718eaba77ccce575834f2cf2a8"
@@ -11893,6 +11912,11 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
+
+typeface-roboto@^0.0.54:
+  version "0.0.54"
+  resolved "https://registry.yarnpkg.com/typeface-roboto/-/typeface-roboto-0.0.54.tgz#8f02c9a18d1cfa7f49381a6ff0d21ff061f38ad2"
+  integrity sha512-sOFA1FXgP0gOgBYlS6irwq6hHYA370KE3dPlgYEJHL3PJd5X8gQE0RmL79ONif6fL5JZuGDj+rtOrFeOqz5IZQ==
 
 ua-parser-js@^0.7.9:
   version "0.7.17"


### PR DESCRIPTION
Adds a XHR-style upload indicator. Useful for bigger imports, so the user gets feedback of the progress. Note that the normal loading indicator is used for the server to process the data.

Needed to add some webpack-config to use the new UI, so the loaders include css from node-modules.

