### PR TITLE
fix(metadata export): filter selectable schemas on metadata and exclude schemas

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "react-router": "^4.2.0",
     "react-router-dom": "^4.2.2",
     "redux": "^3.7.2",
+    "reselect": "^4.0.0",
     "rxjs": "^5.5.7",
     "style-loader": "0.19.0",
     "sw-precache-webpack-plugin": "0.11.4",

--- a/src/components/Form/Schemas/index.js
+++ b/src/components/Form/Schemas/index.js
@@ -9,8 +9,6 @@ import { setSchemas } from 'reducers/'
 import { connect } from 'react-redux'
 import s from './styles.css'
 import { getSortedSchemaGroups, getSchemas } from 'reducers/schemas/selectors'
-import { colors } from 'material-ui/styles'
-import { EditorFormatAlignJustify } from 'material-ui/svg-icons'
 
 function groupName(klass) {
     let group = klass.split('.')

--- a/src/components/Form/Schemas/index.js
+++ b/src/components/Form/Schemas/index.js
@@ -8,11 +8,7 @@ import { EXCLUDE_SCHEMAS } from 'helpers'
 import { setSchemas } from 'reducers/'
 import { connect } from 'react-redux'
 import s from './styles.css'
-import {
-    getSortedSchemaGroups,
-    getSortedSchemas,
-    getSchemas,
-} from 'reducers/schemas/selectors'
+import { getSortedSchemaGroups, getSchemas } from 'reducers/schemas/selectors'
 import { colors } from 'material-ui/styles'
 import { EditorFormatAlignJustify } from 'material-ui/svg-icons'
 
@@ -25,45 +21,6 @@ function groupName(klass) {
     }
 
     return group[group.length - 1]
-}
-
-function schemaGroups(schemas) {
-    const groups = {}
-
-    schemas.forEach(s => {
-        if (!groups[s.group]) {
-            groups[s.group] = []
-        }
-
-        groups[s.group].push(s)
-    })
-
-    // check groups with 1 item and merge inside Other
-    const groupsWith1Item = []
-    const OTHER_GROUP_NAME = 'other'
-    let otherGroup = []
-
-    Object.entries(groups).forEach(([k, v]) => {
-        if (v.length === 1) {
-            groupsWith1Item.push(k)
-            v[0]['group'] = OTHER_GROUP_NAME
-            otherGroup = otherGroup.concat(v)
-        }
-    })
-    groups[OTHER_GROUP_NAME] = otherGroup
-
-    groupsWith1Item.forEach(k => {
-        delete groups[k]
-    })
-
-    // sort group items by length desc
-    // Object.entries(groups).forEach(([k, v]) => {
-    //   groups[k] = groups[k].sort(
-    //     (a, b) => a.displayName.length - b.displayName.length
-    //   )
-    // })
-
-    return groups
 }
 
 function breakOnCamelCase(schemaName, name) {
@@ -165,7 +122,6 @@ export default class Schemas extends React.Component {
         super(props)
 
         this.state = {
-            loaded: false,
             checked:
                 props.schemas.length > 0 ? this.setChecked(null, true) : {},
         }
@@ -226,8 +182,6 @@ export default class Schemas extends React.Component {
             this.props.setSchemas(schemas)
             this.setState(
                 {
-                    loaded: true,
-                    schemas,
                     checked: this.setChecked(null, true, schemas),
                 },
                 () => {
@@ -241,7 +195,6 @@ export default class Schemas extends React.Component {
     }
 
     onSelectNone = () => {
-        const { schemas } = this.props
         this.setState(
             {
                 checked: this.setChecked(null, false),

--- a/src/components/Form/Schemas/index.js
+++ b/src/components/Form/Schemas/index.js
@@ -4,7 +4,7 @@ import i18n from '@dhis2/d2-i18n'
 import { Loading } from 'components'
 import { Checkbox, RaisedButton } from 'material-ui'
 import { FormGroup, FormControl, FormLabel } from '../material-ui'
-
+import { EXCLUDE_SCHEMAS } from 'helpers'
 import s from './styles.css'
 
 function groupName(klass) {
@@ -173,7 +173,9 @@ export default class Schemas extends React.Component {
 
     getSchemas(schemas) {
         return schemas
-            .filter(i => i.metadata)
+            .filter(
+                i => i.metadata && !EXCLUDE_SCHEMAS.includes(i.collectionName)
+            )
             .map(i => ({
                 name: i.name,
                 klass: i.klass,
@@ -187,11 +189,12 @@ export default class Schemas extends React.Component {
     async fetch() {
         try {
             const { data } = await api.get('schemas.json')
+            const schemas = this.getSchemas(data.schemas)
             this.setState(
                 {
                     loaded: true,
-                    schemas: this.getSchemas(data.schemas),
-                    checked: data.schemas.map(item => item.collectionName),
+                    schemas,
+                    checked: schemas.map(item => item.collectionName),
                 },
                 () => {
                     this.props.onChange(this.props.name, this.state.checked)

--- a/src/components/Form/Schemas/index.js
+++ b/src/components/Form/Schemas/index.js
@@ -173,9 +173,7 @@ export default class Schemas extends React.Component {
 
     getSchemas(schemas) {
         return schemas
-            .filter(
-                i => i.metadata && !EXCLUDE_SCHEMAS.includes(i.collectionName)
-            )
+            .filter(i => i.metadata && !EXCLUDE_SCHEMAS.has(i.collectionName))
             .map(i => ({
                 name: i.name,
                 klass: i.klass,

--- a/src/components/Form/Schemas/index.js
+++ b/src/components/Form/Schemas/index.js
@@ -4,12 +4,9 @@ import i18n from '@dhis2/d2-i18n'
 import { Loading } from 'components'
 import { Checkbox, RaisedButton } from 'material-ui'
 import { FormGroup, FormControl, FormLabel } from '../material-ui'
-<<<<<<< Updated upstream
 import { EXCLUDE_SCHEMAS } from 'helpers'
-=======
 import { setSchemas } from 'reducers/'
 import { connect } from 'react-redux'
->>>>>>> Stashed changes
 import s from './styles.css'
 import {
     getSortedSchemaGroups,
@@ -17,6 +14,7 @@ import {
     getSchemas,
 } from 'reducers/schemas/selectors'
 import { colors } from 'material-ui/styles'
+import { EditorFormatAlignJustify } from 'material-ui/svg-icons'
 
 function groupName(klass) {
     let group = klass.split('.')
@@ -171,20 +169,26 @@ export default class Schemas extends React.Component {
             checked:
                 props.schemas.length > 0 ? this.setChecked(null, true) : {},
         }
-        console.log(this.setChecked(null, true))
     }
 
     async componentDidMount() {
-        this.fetch()
+        if (this.props.schemas.length < 1) {
+            this.fetch()
+        }
     }
 
+    /**
+     * Helper to handle setting checked-State. Note does not actually call setState,
+     * returns an object of the checked state.
+     * @param {f} collectionName if falsy, set all schemas to value - else, only update collectionName.
+     * @param {*} value value to set (true or false)
+     * @param {*} schemas schemas to use if collectionName is falsy
+     */
     setChecked(collectionName, value, schemas = this.props.schemas) {
-        console.log(collectionName)
-        let ret
         if (collectionName) {
-            ret = { ...this.state.checked, [collectionName]: value }
+            return { ...this.state.checked, [collectionName]: value }
         } else {
-            ret = schemas.reduce(
+            return schemas.reduce(
                 (accum, { collectionName: colName }) => ({
                     ...accum,
                     [colName]: value,
@@ -192,8 +196,6 @@ export default class Schemas extends React.Component {
                 {}
             )
         }
-        console.log(ret)
-        return ret
     }
 
     onClick = (collectionName, isChecked) => {
@@ -222,7 +224,7 @@ export default class Schemas extends React.Component {
             const { data } = await api.get('schemas.json')
             const schemas = this.getSchemas(data.schemas)
             this.props.setSchemas(schemas)
-            const checked = this.setState(
+            this.setState(
                 {
                     loaded: true,
                     schemas,

--- a/src/helpers/fields.js
+++ b/src/helpers/fields.js
@@ -92,7 +92,7 @@ const fields = {
     ),
     mergeMode: getField('mergeMode', i18n.t('Merge Mode'), TYPE_RADIO),
     objectList: getField('objectList', i18n.t('Object'), TYPE_SELECT),
-    objectType: getField('objectType', i18n.t('Object type'), TYPE_SELECT),
+    objectType: getField('objectType', i18n.t('Object type'), TYPE_RADIO),
     orgUnit: getField('orgUnit', i18n.t('Organisation unit'), TYPE_ORG_UNIT),
     orgUnitIdScheme: getField(
         'orgUnitIdScheme',

--- a/src/helpers/values.js
+++ b/src/helpers/values.js
@@ -303,3 +303,33 @@ export function getFormValues(list) {
 
     return o
 }
+
+export const EXCLUDE_SCHEMAS = [
+    'analyticsTableHooks',
+    'charts',
+    'constants',
+    'dataElementDimensions',
+    'dataEntryForms',
+    'dataSetNotificationTemplates',
+    'dataStores',
+    'documents',
+    'eventCharts',
+    'eventReports',
+    'icons',
+    'jobConfigurations',
+    'messageConversations',
+    'metadataVersions',
+    'minMaxDataElements',
+    'oAuth2Clients',
+    'programDataElements',
+    'programNotificationTemplates',
+    'pushAnalysis',
+    'reportTables',
+    'reportingRates',
+    'reports',
+    'sections',
+    'smsCommands',
+    'sqlViews',
+    'trackedEntityInstanceFilters',
+    'validationNotificationTemplates',
+]

--- a/src/helpers/values.js
+++ b/src/helpers/values.js
@@ -304,7 +304,7 @@ export function getFormValues(list) {
     return o
 }
 
-export const EXCLUDE_SCHEMAS = [
+export const EXCLUDE_SCHEMAS = new Set([
     'analyticsTableHooks',
     'charts',
     'constants',
@@ -332,4 +332,4 @@ export const EXCLUDE_SCHEMAS = [
     'sqlViews',
     'trackedEntityInstanceFilters',
     'validationNotificationTemplates',
-]
+])

--- a/src/pages/export/MetaData.js
+++ b/src/pages/export/MetaData.js
@@ -45,8 +45,8 @@ export class MetaDataExport extends FormBase {
                 endpoint,
                 sharing,
             })
-            const schemaParams = schemas
-                .sort()
+            const schemaParams = Object.keys(schemas)
+                .filter(s => schemas[s])
                 .map(name => `${name}=true`)
                 .join('&')
 

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,9 +1,11 @@
 import { combineReducers } from 'redux'
 
 import user from './user'
-
+import schemas from './schemas'
 export * from 'reducers/user/actions'
+export * from 'reducers/schemas/actions'
 
 export default combineReducers({
     user,
+    schemas,
 })

--- a/src/reducers/schemas/actions.js
+++ b/src/reducers/schemas/actions.js
@@ -1,0 +1,5 @@
+export const SCHEMAS_SET = 'schemas/SET'
+export const SCHEMAS_CLEAR = 'schemas/CLEAR'
+
+export const setSchemas = user => ({ type: SCHEMAS_SET, payload: user })
+export const clearSchemas = () => ({ type: SCHEMAS_CLEAR })

--- a/src/reducers/schemas/actions.js
+++ b/src/reducers/schemas/actions.js
@@ -1,5 +1,5 @@
 export const SCHEMAS_SET = 'schemas/SET'
 export const SCHEMAS_CLEAR = 'schemas/CLEAR'
 
-export const setSchemas = user => ({ type: SCHEMAS_SET, payload: user })
+export const setSchemas = schemas => ({ type: SCHEMAS_SET, payload: schemas })
 export const clearSchemas = () => ({ type: SCHEMAS_CLEAR })

--- a/src/reducers/schemas/index.js
+++ b/src/reducers/schemas/index.js
@@ -1,0 +1,15 @@
+import { SCHEMAS_SET } from './actions'
+
+const initialState = { loaded: false, loading: true, error: false, list: [] }
+const loadedState = { loaded: true, loading: false, error: false }
+export * from './actions'
+
+export default function schemasReducer(state = initialState, action) {
+    const { type, payload } = action
+
+    if (type === SCHEMAS_SET) {
+        return { ...loadedState, list: payload }
+    }
+
+    return state
+}

--- a/src/reducers/schemas/selectors.js
+++ b/src/reducers/schemas/selectors.js
@@ -1,0 +1,42 @@
+import { createSelector } from 'reselect'
+
+// Groups schemas into groups
+// Ie. All Data Element related into 'dataElement'
+function schemaGroups(schemas) {
+    const groups = {}
+
+    schemas.forEach(s => {
+        if (!groups[s.group]) {
+            groups[s.group] = []
+        }
+
+        groups[s.group].push(s)
+    })
+
+    // check groups with 1 item and merge inside Other
+    const groupsWith1Item = []
+    const OTHER_GROUP_NAME = 'other'
+    let otherGroup = []
+
+    Object.entries(groups).forEach(([k, v]) => {
+        if (v.length === 1) {
+            groupsWith1Item.push(k)
+            v[0]['group'] = OTHER_GROUP_NAME
+            otherGroup = otherGroup.concat(v)
+        }
+    })
+    groups[OTHER_GROUP_NAME] = otherGroup
+
+    groupsWith1Item.forEach(k => {
+        delete groups[k]
+    })
+
+    return groups
+}
+
+export const getSchemas = state => state.schemas.list
+
+export const getSortedSchemaGroups = createSelector(
+    state => getSchemas(state),
+    schemas => schemaGroups(schemas)
+)

--- a/yarn.lock
+++ b/yarn.lock
@@ -9128,6 +9128,11 @@ requizzle@~0.2.1:
   dependencies:
     underscore "~1.6.0"
 
+reselect@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.0.0.tgz#f2529830e5d3d0e021408b246a206ef4ea4437f7"
+  integrity sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==
+
 resolve-cwd@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"


### PR DESCRIPTION
See https://jira.dhis2.org/browse/DHIS2-5680.

When loading schemas, it preselected all schemas before filtering in metadata. Now also filters on the EXCLUDE_SCHEMAS list, as a workaround described in the ticket above. 

There seemed to be some performance problems with the schema-list - both with rendering and fetching unecessary. Ive now put the fetched list in the redux-store so it does not fetch each time an user visits the 'Metadata Export'-page.
Also moved 'checked' to be an Object instead of list, to improve rendering (so each item does not need to loop through the checked list - now just a O(1) operation).