### PR TITLE
refactor(import meta data): rename import mode labels to dry run

### DIFF
--- a/src/helpers/fields.js
+++ b/src/helpers/fields.js
@@ -70,7 +70,7 @@ const fields = {
     format: getField('format', i18n.t('Format'), TYPE_RADIO),
     idScheme: getField('idScheme', i18n.t('ID scheme'), TYPE_RADIO),
     identifier: getField('identifier', i18n.t('Identifier'), TYPE_RADIO),
-    importMode: getField('importMode', i18n.t('Import Mode'), TYPE_RADIO),
+    importMode: getField('importMode', i18n.t('Dry run'), TYPE_RADIO),
     importReportMode: getField(
         'importReportMode',
         i18n.t('Report Mode'),

--- a/src/helpers/values.js
+++ b/src/helpers/values.js
@@ -124,8 +124,8 @@ const values = {
     importMode: {
         selected: 'COMMIT',
         values: getValues([
-            ['COMMIT', i18n.t('Commit')],
-            ['VALIDATE', i18n.t('Validate')],
+            ['VALIDATE', i18n.t('Yes')],
+            ['COMMIT', i18n.t('No')],
         ]),
     },
 

--- a/src/pages/import/MetaData.js
+++ b/src/pages/import/MetaData.js
@@ -33,10 +33,9 @@ export class MetaDataImport extends FormBase {
         ...getFormFields([
             'upload',
             'format',
-            'dryRun',
+            'importMode',
             'firstRowIsHeader',
             'classKey',
-            'importMode',
             'identifier',
             'importReportMode',
             'preheatMode',


### PR DESCRIPTION
Fixes [DHIS2-6379](https://jira.dhis2.org/browse/DHIS2-6379)

Import mode is used in meta data import only, so simply renaming it should be safe.
I've moved it up to where the old "Dry run" previously was.