### PR TITLE
WIP: fix: use selected format instead of file extension for Content-Type header

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2019-04-09T14:14:19.008Z\n"
-"PO-Revision-Date: 2019-04-09T14:14:19.008Z\n"
+"POT-Creation-Date: 2019-07-12T06:06:14.220Z\n"
+"PO-Revision-Date: 2019-07-12T06:06:14.220Z\n"
 
 msgid "user is not logged in"
 msgstr ""
@@ -140,9 +140,6 @@ msgstr ""
 msgid "Identifier"
 msgstr ""
 
-msgid "Import Mode"
-msgstr ""
-
 msgid "Report Mode"
 msgstr ""
 
@@ -249,12 +246,6 @@ msgid "Skip check (fast)"
 msgstr ""
 
 msgid "Check (safe, recommended)"
-msgstr ""
-
-msgid "Commit"
-msgstr ""
-
-msgid "Validate"
 msgstr ""
 
 msgid "AUTO"

--- a/src/helpers/mime.js
+++ b/src/helpers/mime.js
@@ -4,6 +4,7 @@ const mapping = {
     csv: 'application/csv',
     gml: 'application/xml',
     adx: 'application/adx+xml',
+    pdf: 'application/pdf',
 }
 
 export const getMimeType = format => mapping[format] || null

--- a/src/helpers/mime.js
+++ b/src/helpers/mime.js
@@ -1,22 +1,9 @@
-export function getMimeType(filename) {
-    if (!filename) {
-        return null
-    }
-
-    const isJSON = filename.endsWith('json') || filename.includes('.json')
-    const isXML = filename.endsWith('xml') || filename.includes('.xml')
-    const isCSV = filename.endsWith('csv') || filename.includes('.csv')
-    const isGML = filename.endsWith('gml') || filename.includes('.gml')
-
-    if (isJSON) {
-        return 'application/json'
-    } else if (isXML) {
-        return 'application/xml'
-    } else if (isCSV) {
-        return 'application/csv'
-    } else if (isGML) {
-        return 'application/xml'
-    }
-
-    return null
+const mapping = {
+    json: 'application/json',
+    xml: 'application/xml',
+    csv: 'application/csv',
+    gml: 'application/xml',
+    adx: 'application/adx+xml',
 }
+
+export const getMimeType = format => mapping[format] || null

--- a/src/helpers/xhr.js
+++ b/src/helpers/xhr.js
@@ -3,9 +3,9 @@ import { eventEmitter } from '../services'
 import { emitLogOnFirstResponse, fetchLog } from '../pages/import/helpers'
 
 // eslint-disable-next-line max-params
-export function getUploadXHR(url, upload, type, onResponse, onError) {
+export function getUploadXHR(url, upload, type, onResponse, onError, format) {
     const xhr = new XMLHttpRequest()
-    const contentType = getMimeType(upload.name.toLowerCase())
+    const contentType = getMimeType(format)
 
     xhr.withCredentials = true
     xhr.open('POST', url, true)

--- a/src/pages/import/Data.js
+++ b/src/pages/import/Data.js
@@ -80,10 +80,11 @@ export class DataImport extends FormBase {
     onSubmit = () => {
         try {
             const { upload, format, firstRowIsHeader } = this.getFormState()
-            let append = [`format=${format.substr(1)}`, 'async=true']
+            const formattedFormat = format.substr(1)
+            const append = [`format=${formattedFormat}`, 'async=true']
 
             if (format === '.csv') {
-                append = [...append, `firstRowIsHeader=${firstRowIsHeader}`]
+                append.push(`firstRowIsHeader=${firstRowIsHeader}`)
             }
 
             const params = getParamsFromFormState(
@@ -109,7 +110,8 @@ export class DataImport extends FormBase {
                 upload,
                 'DATAVALUE_IMPORT',
                 this.clearProcessing,
-                this.assertOnError
+                this.assertOnError,
+                formattedFormat
             )
 
             xhr.send(upload)

--- a/src/pages/import/Event.js
+++ b/src/pages/import/Event.js
@@ -48,6 +48,7 @@ export class EventImport extends FormBase {
     onSubmit = async () => {
         try {
             const { upload, format } = this.getFormState()
+            const formattedFormat = format.slice(1)
 
             const params = getParamsFromFormState(
                 this.getFormState(),
@@ -55,7 +56,7 @@ export class EventImport extends FormBase {
                 [
                     'async=true',
                     'skipFirst=true',
-                    `payloadFormat=${format.slice(1)}`,
+                    `payloadFormat=${formattedFormat}`,
                 ]
             )
             this.setProcessing()
@@ -67,7 +68,8 @@ export class EventImport extends FormBase {
                 upload,
                 'EVENT_IMPORT',
                 this.clearProcessing,
-                this.assertOnError
+                this.assertOnError,
+                formattedFormat
             )
             xhr.send(upload)
         } catch (e) {

--- a/src/pages/import/GML.js
+++ b/src/pages/import/GML.js
@@ -48,7 +48,8 @@ export class GMLImport extends FormBase {
                 upload,
                 'GML_IMPORT',
                 this.clearProcessing,
-                this.assertOnError
+                this.assertOnError,
+                'gml'
             )
             xhr.send(upload)
         } catch (e) {

--- a/src/pages/import/MetaData.js
+++ b/src/pages/import/MetaData.js
@@ -176,7 +176,8 @@ export class MetaDataImport extends FormBase {
                 upload,
                 'METADATA_IMPORT',
                 this.clearProcessing,
-                this.assertOnError
+                this.assertOnError,
+                format.substr(1)
             )
             xhr.send(upload)
         } catch (e) {


### PR DESCRIPTION
This PR will change the way what `Content-Type` header is being sent with the request.
This will allow to send `.zip` files without having to have `.json.zip` as file extension.

Fixes DHIS2-6247 (https://jira.dhis2.org/browse/DHIS2-6247)
<hr />

WIP: Needs more testing