### PR TITLE
refactor(event & gml import pages): use final-form & new components

### DIFF
--- a/src/components/FinalFormComponents/File.js
+++ b/src/components/FinalFormComponents/File.js
@@ -30,7 +30,7 @@ export const File = ({ name }) => {
         <div className={styles.container}>
             <input {...withoutValue} ref={ref} className={styles.input} />
 
-            <button onClick={onClick} className={styles.button}>
+            <button type="button" onClick={onClick} className={styles.button}>
                 <FileUploadIcon />
                 <span className={styles.label}>{label}</span>
             </button>

--- a/src/components/FinalFormComponents/__test__/__snapshots__/File.test.js.snap
+++ b/src/components/FinalFormComponents/__test__/__snapshots__/File.test.js.snap
@@ -12,6 +12,7 @@ exports[`Form component - File should render correctly 1`] = `
   <button
     className="button"
     onClick={[Function]}
+    type="button"
   >
     <FileUploadIcon />
     <span

--- a/src/components/Inputs/EventIdScheme.js
+++ b/src/components/Inputs/EventIdScheme.js
@@ -1,0 +1,17 @@
+import i18n from '@dhis2/d2-i18n'
+import React from 'react'
+import { RadioGroup } from '../FinalFormComponents/RadioGroup'
+
+export const OPTION_UID = { value: 'UID', label: i18n.t('Uid') }
+export const OPTION_CODE = { value: 'CODE', label: i18n.t('Code') }
+
+export const EVENT_ID_SCHEME_KEY = 'eventIdScheme'
+export const EVENT_ID_SCHEME_DEFAULT_VALUE = OPTION_UID.value
+
+export const EventIdScheme = () => (
+    <RadioGroup
+        name={EVENT_ID_SCHEME_KEY}
+        label={i18n.t('Event id scheme')}
+        options={[OPTION_UID, OPTION_CODE]}
+    />
+)

--- a/src/pages/import/Data.js
+++ b/src/pages/import/Data.js
@@ -4,6 +4,7 @@ import React, { useState } from 'react'
 import cx from 'classnames'
 import i18n from '@dhis2/d2-i18n'
 
+import { TaskSummary } from '../../components/TaskSummary'
 import { DataElementIdScheme } from '../../components/Inputs/DataElementIdScheme'
 import { DataIcon } from '../../components/Icon'
 import { DryRun } from '../../components/Inputs/DryRun'
@@ -51,6 +52,7 @@ export const DataImport = () => {
         <Form onSubmit={onSubmitHandler} initialValues={defaultValues}>
             {({ handleSubmit, values }) => (
                 <div className={stylesForm.wrapper}>
+                    <TaskSummary />
                     <form
                         className={cx(stylesFormBase.form, stylesForm.form)}
                         onSubmit={handleSubmit}

--- a/src/pages/import/Event.js
+++ b/src/pages/import/Event.js
@@ -4,6 +4,7 @@ import React, { useState } from 'react'
 import cx from 'classnames'
 import i18n from '@dhis2/d2-i18n'
 
+import { TaskSummary } from '../../components/TaskSummary'
 import { DryRun } from '../../components/Inputs/DryRun'
 import { Error } from '../../components/Error'
 import { EventIcon } from '../../components/Icon'
@@ -31,6 +32,7 @@ export const EventImport = () => {
         <Form onSubmit={onSubmitHandler} initialValues={defaultValues}>
             {({ handleSubmit, values }) => (
                 <div className={stylesForm.wrapper}>
+                    <TaskSummary />
                     <form
                         className={cx(stylesFormBase.form, stylesForm.form)}
                         onSubmit={handleSubmit}

--- a/src/pages/import/Event.js
+++ b/src/pages/import/Event.js
@@ -1,81 +1,69 @@
-import React from 'react'
+import { Button } from '@dhis2/ui-core'
+import { Form } from 'react-final-form'
+import React, { useState } from 'react'
+import cx from 'classnames'
 import i18n from '@dhis2/d2-i18n'
 
-import { CTX_DEFAULT } from '../../components/Form'
+import { DryRun } from '../../components/Inputs/DryRun'
+import { Error } from '../../components/Error'
 import { EventIcon } from '../../components/Icon'
-import { FormBase } from '../../components/FormBase'
-import { fetchLog } from './helpers'
-import {
-    getFormField,
-    getFormFields,
-    getFormValues,
-    getParamsFromFormState,
-    getUploadXHR,
-} from '../../helpers'
-import { isProduction } from '../../helpers/env'
+import { FormContent } from '../../components/FormSections/FormContent'
+import { FormFooter } from '../../components/FormSections/FormFooter'
+import { FormHeader } from '../../components/FormSections/FormHeader'
+import { EventIdScheme } from '../../components/Inputs/EventIdScheme'
+import { Format } from '../../components/Inputs/Format'
+import { OrgUnitIdScheme } from '../../components/Inputs/OrgUnitIdScheme'
+import { Progress } from '../../components/Loading/Progress'
+import { Upload } from '../../components/Inputs/Upload'
+import { supportedFormats, defaultValues, onSubmit } from './Event/helper'
+import stylesForm from '../../components/Form/styles.module.css'
+import stylesFormBase from '../../components/FormBase/styles.module.css'
 
-export class EventImport extends FormBase {
-    static path = '/import/event'
+export const EventImport = () => {
+    const [loading, setLoading] = useState(false)
+    const [error, setError] = useState('')
+    const onSubmitHandler = onSubmit(setLoading, setError)
 
-    static order = 3
-    static title = i18n.t('Event Import')
-    static desc = i18n.t(
-        'Import events for programs, stages and tracked entities in the DXF 2 format.'
+    if (error) return <Error message={error} onClear={() => setError('')} />
+    if (loading) return <Progress />
+
+    return (
+        <Form onSubmit={onSubmitHandler} initialValues={defaultValues}>
+            {({ handleSubmit, values }) => (
+                <div className={stylesForm.wrapper}>
+                    <form
+                        className={cx(stylesFormBase.form, stylesForm.form)}
+                        onSubmit={handleSubmit}
+                        style={{ width: 800 }}
+                    >
+                        <FormHeader
+                            icon={EventImport.menuIcon}
+                            label={EventImport.title}
+                        />
+
+                        <FormContent>
+                            <Upload />
+                            <Format options={supportedFormats} />
+                            <DryRun />
+                            <EventIdScheme />
+                            <OrgUnitIdScheme />
+                        </FormContent>
+
+                        <FormFooter>
+                            <Button primary type="submit">
+                                {i18n.t('Import')}
+                            </Button>
+                        </FormFooter>
+                    </form>
+                </div>
+            )}
+        </Form>
     )
-
-    static menuIcon = <EventIcon />
-    icon = <EventIcon />
-
-    formWidth = 800
-    formTitle = i18n.t('Event Import')
-    submitLabel = i18n.t('Import')
-
-    fields = [
-        ...getFormFields(['upload', 'format', 'dryRun', 'eventIdScheme']),
-        getFormField('orgUnitIdScheme', { context: CTX_DEFAULT }),
-    ]
-
-    state = getFormValues([
-        'upload',
-        'format:.json:json,xml,csv',
-        'dryRun',
-        'eventIdScheme',
-        'orgUnitIdScheme',
-    ])
-
-    async componentDidMount() {
-        await fetchLog('', 'EVENT_IMPORT')
-    }
-
-    onSubmit = async () => {
-        try {
-            const { upload, format } = this.getFormState()
-            const formattedFormat = format.slice(1)
-
-            const params = getParamsFromFormState(
-                this.getFormState(),
-                ['dryRun', 'eventIdScheme', 'orgUnitIdScheme'],
-                [
-                    'async=true',
-                    'skipFirst=true',
-                    `payloadFormat=${formattedFormat}`,
-                ]
-            )
-            this.setProcessing()
-
-            const { REACT_APP_DHIS2_BASE_URL } = process.env
-            const url = `${REACT_APP_DHIS2_BASE_URL}/api/events.json?${params}`
-            const xhr = getUploadXHR(
-                url,
-                upload,
-                'EVENT_IMPORT',
-                this.clearProcessing,
-                this.assertOnError,
-                formattedFormat
-            )
-            xhr.send(upload)
-        } catch (e) {
-            !isProduction && console.log('Event Import error', e, '\n')
-        }
-    }
 }
+EventImport.path = '/import/event'
+EventImport.title = i18n.t('Event Import')
+EventImport.desc = i18n.t(
+    'Import events for programs, stages and tracked entities in the DXF 2 format.'
+)
+
+EventImport.menuIcon = <EventIcon />

--- a/src/pages/import/Event/helper.js
+++ b/src/pages/import/Event/helper.js
@@ -1,0 +1,71 @@
+import i18n from '@dhis2/d2-i18n'
+
+import {
+    DRY_RUN_DEFAULT_VALUE,
+    DRY_RUN_KEY,
+} from '../../../components/Inputs/DryRun'
+import {
+    EVENT_ID_SCHEME_DEFAULT_VALUE,
+    EVENT_ID_SCHEME_KEY,
+} from '../../../components/Inputs/EventIdScheme'
+import {
+    FORMAT_DEFAULT_VALUE,
+    FORMAT_KEY,
+    OPTION_CSV,
+    OPTION_JSON,
+    OPTION_XML,
+} from '../../../components/Inputs/Format'
+import {
+    ORG_UNIT_ID_SCHEME_DEFAULT_VALUE,
+    ORG_UNIT_ID_SCHEME_KEY,
+} from '../../../components/Inputs/OrgUnitIdScheme'
+import { getParamsFromFormState, getUploadXHR } from '../../../helpers'
+import { isProduction } from '../../../helpers/env'
+
+export const supportedFormats = [OPTION_JSON, OPTION_XML, OPTION_CSV]
+
+export const defaultValues = {
+    [FORMAT_KEY]: FORMAT_DEFAULT_VALUE,
+    [DRY_RUN_KEY]: DRY_RUN_DEFAULT_VALUE,
+    [EVENT_ID_SCHEME_KEY]: EVENT_ID_SCHEME_DEFAULT_VALUE,
+    [ORG_UNIT_ID_SCHEME_KEY]: ORG_UNIT_ID_SCHEME_DEFAULT_VALUE,
+}
+
+export const onSubmit = (setLoading, setError) => values => {
+    try {
+        const { upload, format } = values
+
+        const params = getParamsFromFormState(
+            values,
+            ['dryRun', 'eventIdScheme', 'orgUnitIdScheme'],
+            ['async=true', 'skipFirst=true', `payloadFormat=${format}`]
+        )
+        setLoading(true)
+
+        const { REACT_APP_DHIS2_BASE_URL } = process.env
+        const url = `${REACT_APP_DHIS2_BASE_URL}/api/events.json?${params}`
+        const xhr = getUploadXHR(
+            url,
+            upload,
+            'EVENT_IMPORT',
+            () => setLoading(false),
+            e => {
+                let message = i18n.t('An unknown error occurred')
+
+                try {
+                    const response = JSON.parse(e.target.response)
+                    message = response.message
+                } catch (e2) {}
+
+                setError(message)
+                setLoading(false)
+            },
+            format
+        )
+        xhr.send(upload)
+    } catch (e) {
+        !isProduction && console.log('Event Import error', e, '\n')
+        setError('MetaData Import error')
+        setLoading(false)
+    }
+}

--- a/src/pages/import/GML.js
+++ b/src/pages/import/GML.js
@@ -1,12 +1,7 @@
 import React, { useState } from 'react'
 import i18n from '@dhis2/d2-i18n'
 
-import { FormBase } from '../../components/FormBase'
 import { GMLIcon } from '../../components/Icon'
-import { fetchLog } from './helpers'
-import { getFormFields, getFormValues, getUploadXHR } from '../../helpers'
-import { isProduction } from '../../helpers/env'
-
 import { TaskSummary } from '../../components/TaskSummary'
 import { Error } from '../../components/Error'
 import { Progress } from '../../components/Loading/Progress'

--- a/src/pages/import/GML.js
+++ b/src/pages/import/GML.js
@@ -7,6 +7,7 @@ import { fetchLog } from './helpers'
 import { getFormFields, getFormValues, getUploadXHR } from '../../helpers'
 import { isProduction } from '../../helpers/env'
 
+import { TaskSummary } from '../../components/TaskSummary'
 import { Error } from '../../components/Error'
 import { Progress } from '../../components/Loading/Progress'
 import { Button } from '@dhis2/ui-core'
@@ -33,6 +34,7 @@ export const GMLImport = () => {
         <Form onSubmit={onSubmitHandler} initialValues={defaultValues}>
             {({ handleSubmit, values }) => (
                 <div className={stylesForm.wrapper}>
+                    <TaskSummary />
                     <form
                         className={cx(stylesFormBase.form, stylesForm.form)}
                         onSubmit={handleSubmit}

--- a/src/pages/import/GML/helper.js
+++ b/src/pages/import/GML/helper.js
@@ -4,7 +4,7 @@ import {
     DRY_RUN_DEFAULT_VALUE,
     DRY_RUN_KEY,
 } from '../../../components/Inputs/DryRun'
-import { getParamsFromFormState, getUploadXHR } from '../../../helpers'
+import { getUploadXHR } from '../../../helpers'
 import { isProduction } from '../../../helpers/env'
 
 export const defaultValues = {

--- a/src/pages/import/GML/helper.js
+++ b/src/pages/import/GML/helper.js
@@ -1,0 +1,50 @@
+import i18n from '@dhis2/d2-i18n'
+
+import {
+    DRY_RUN_DEFAULT_VALUE,
+    DRY_RUN_KEY,
+} from '../../../components/Inputs/DryRun'
+import { getParamsFromFormState, getUploadXHR } from '../../../helpers'
+import { isProduction } from '../../../helpers/env'
+
+export const defaultValues = {
+    [DRY_RUN_KEY]: DRY_RUN_DEFAULT_VALUE,
+}
+
+export const onSubmit = (setLoading, setError) => values => {
+    try {
+        const { upload, dryRun } = values
+
+        const formData = new FormData()
+        formData.set('upload', upload)
+
+        setLoading(true)
+
+        const params = `dryRun=${dryRun}&format=json`
+        const { REACT_APP_DHIS2_BASE_URL } = process.env
+        const url = `${REACT_APP_DHIS2_BASE_URL}/api/metadata/gml?${params}`
+        const xhr = getUploadXHR(
+            url,
+            upload,
+            'GML_IMPORT',
+            () => setLoading(false),
+            e => {
+                let message = i18n.t('An unknown error occurred')
+
+                try {
+                    const response = JSON.parse(e.target.response)
+                    message = response.message
+                } catch (e2) {}
+
+                setError(message)
+                setLoading(false)
+            },
+            'gml'
+        )
+        xhr.send(upload)
+    } catch (e) {
+        !isProduction && console.log('GML Import error', e, '\n')
+        setError('GML Import error')
+        setLoading(false)
+    }
+}

--- a/src/pages/import/MetaData.js
+++ b/src/pages/import/MetaData.js
@@ -4,6 +4,7 @@ import React, { useState } from 'react'
 import cx from 'classnames'
 import i18n from '@dhis2/d2-i18n'
 
+import { TaskSummary } from '../../components/TaskSummary'
 import { Async } from '../../components/Inputs/Async'
 import { AtomicMode } from '../../components/Inputs/AtomicMode'
 import { ClassKey } from '../../components/Inputs/ClassKey'
@@ -52,6 +53,7 @@ export const MetaDataImport = () => {
         <Form onSubmit={onSubmitHandler} initialValues={defaultValues}>
             {({ handleSubmit, values }) => (
                 <div className={stylesForm.wrapper}>
+                    <TaskSummary />
                     <form
                         className={cx(stylesFormBase.form, stylesForm.form)}
                         onSubmit={handleSubmit}

--- a/src/pages/import/helpers.js
+++ b/src/pages/import/helpers.js
@@ -102,6 +102,8 @@ export async function fetchLog(jobId, type) {
 
             if (isFetchLogComplete(data)) {
                 fetchLogAfter(jobId, type)
+            } else {
+                await fetchTaskSummary(jobId, type)
             }
         } else if (fetchResponseIsObject(data)) {
             let records = null


### PR DESCRIPTION
Fixes DHIS2-7207

Implements the use of the new style already used on the metadata and data import pages also on the event and gml import pages.

It also
* fixes a bug introduced in v33 (DHIS2-7207)
* fixes a bug introduced by the final-form refactoring (clicking the file upload input triggers a submit)
(which is not a problem because the form can't be submitted until the file input has a value, but the required message is shown before the file dialog pops up)

Note: The refactoring so far only has been done on the way forms are implemented. The overall logic has not been refactored (yet). @ismay has made some comments in regards to what could/should be changed as well, we agreed on that being a topic for a different PR though

<hr />

Best way to check whether everything is still working is by comparing the payload/response to/from the server with the live version ([2.33 Import-Export app](https://play.dhis2.org/dev/dhis-web-import-export))