### PR TITLE
Dynamic attribute options on Data ex- & import pages

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2019-08-30T08:44:31.946Z\n"
-"PO-Revision-Date: 2019-08-30T08:44:31.946Z\n"
+"POT-Creation-Date: 2019-12-19T10:07:59.315Z\n"
+"PO-Revision-Date: 2019-12-19T10:07:59.315Z\n"
 
 msgid "user is not logged in"
 msgstr ""
@@ -221,9 +221,6 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-msgid "HR identifier"
-msgstr ""
-
 msgid "Include descendants of organisation unit"
 msgstr ""
 
@@ -338,6 +335,9 @@ msgstr ""
 msgid ""
 "Export data values. This is the regular export function which exports data "
 "to the DHIS 2 exchange format called DXF 2."
+msgstr ""
+
+msgid "Loading options..."
 msgstr ""
 
 msgid "Event Export"

--- a/package.json
+++ b/package.json
@@ -160,6 +160,7 @@
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jest": "^21.26.2",
     "eslint-plugin-jsx-a11y": "^6.1.2",
-    "eslint-plugin-react": "^7.11.1"
+    "eslint-plugin-react": "^7.11.1",
+    "redux-mock-store": "^1.5.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -53,6 +53,8 @@
     "react-router": "^4.2.0",
     "react-router-dom": "^4.2.2",
     "redux": "^3.7.2",
+    "redux-devtools-extension": "^2.13.8",
+    "redux-thunk": "^2.3.0",
     "reselect": "^4.0.0",
     "rxjs": "^5.5.7",
     "style-loader": "0.19.0",

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,16 +1,18 @@
-import React from 'react'
-import ReactDOM from 'react-dom'
 import { Provider } from 'react-redux'
 import { HashRouter } from 'react-router-dom'
-
 import { MuiThemeProvider } from 'material-ui'
+import React from 'react'
+import ReactDOM from 'react-dom'
 import lightBaseTheme from 'material-ui/styles/baseThemes/lightBaseTheme'
 import getMuiTheme from 'material-ui/styles/getMuiTheme'
 
 import App from './App'
-import { store } from './store'
+import { configureStore } from './configureStore'
+
+jest.mock('./configureStore')
 
 const muiTheme = getMuiTheme(lightBaseTheme)
+const store = configureStore()
 
 it('renders without crashing', () => {
     const div = document.createElement('div')

--- a/src/__mocks__/configureStore.js
+++ b/src/__mocks__/configureStore.js
@@ -1,0 +1,6 @@
+import { compose, createStore, applyMiddleware } from 'redux'
+import reducers from '../reducers'
+import reduxThunk from 'redux-thunk'
+
+export const configureStore = () =>
+    createStore(reducers, compose(applyMiddleware(reduxThunk)))

--- a/src/components/Form/Radio/styles.css
+++ b/src/components/Form/Radio/styles.css
@@ -14,9 +14,12 @@ form .formLabel {
 form .radioGroup {
     display: flex;
     flex-direction: row;
+    flex-wrap: wrap;
+    margin-top: -5px;
 }
 form .radioGroup > div {
     margin-right: 15px;
+    margin-top: 5px;
 }
 form .radioGroup > div:last-child {
     margin-right: 0;

--- a/src/components/Form/Schemas/__tests__/Schemas.test.js
+++ b/src/components/Form/Schemas/__tests__/Schemas.test.js
@@ -1,17 +1,18 @@
 import React from 'react'
 import { mount } from 'enzyme'
 import { Provider } from 'react-redux'
-import Schemas from '../'
-import { Loading } from '../../../Loading'
-
 import { MuiThemeProvider } from 'material-ui'
 import lightBaseTheme from 'material-ui/styles/baseThemes/lightBaseTheme'
 import getMuiTheme from 'material-ui/styles/getMuiTheme'
 
-import { store } from 'store'
+import Schemas from '../'
+import { Loading } from '../../../Loading'
+import { configureStore } from '../../../../configureStore'
+
+jest.mock('../../../../configureStore')
 
 const muiTheme = getMuiTheme(lightBaseTheme)
-
+const store = configureStore()
 const Wrapper = props => (
     <Provider store={store}>
         <MuiThemeProvider muiTheme={muiTheme}>

--- a/src/components/Form/index.js
+++ b/src/components/Form/index.js
@@ -31,7 +31,7 @@ export * from './constants'
 
 export class Form extends React.Component {
     fields() {
-        const { fields, fieldValues } = this.props
+        const { fields, fieldValues, fieldValueOverrides } = this.props
         const { _context: context, _meta: formMeta } = fieldValues
 
         return fields.map(field => {
@@ -43,7 +43,9 @@ export class Form extends React.Component {
             const props = { name, label, className, required, formMeta }
 
             if (type === TYPE_RADIO) {
-                props['values'] = fieldValues[name]['values']
+                props['values'] = fieldValueOverrides[name]
+                  ? fieldValueOverrides[name]
+                  : fieldValues[name]['values']
                 props['selected'] = fieldValues[name]['selected']
 
                 return (

--- a/src/components/Form/index.js
+++ b/src/components/Form/index.js
@@ -31,7 +31,7 @@ export * from './constants'
 
 export class Form extends React.Component {
     fields() {
-        const { fields, fieldValues, fieldValueOverrides } = this.props
+        const { fields, fieldValues, fieldValuesOverride } = this.props
         const { _context: context, _meta: formMeta } = fieldValues
 
         return fields.map(field => {
@@ -43,9 +43,9 @@ export class Form extends React.Component {
             const props = { name, label, className, required, formMeta }
 
             if (type === TYPE_RADIO) {
-                props['values'] = fieldValueOverrides[name]
-                  ? fieldValueOverrides[name]
-                  : fieldValues[name]['values']
+                props['values'] = fieldValuesOverride[name]
+                    ? fieldValuesOverride[name]
+                    : fieldValues[name]['values']
                 props['selected'] = fieldValues[name]['selected']
 
                 return (
@@ -56,7 +56,9 @@ export class Form extends React.Component {
                     />
                 )
             } else if (type === TYPE_SELECT) {
-                props['values'] = fieldValues[name]['values']
+                props['values'] = fieldValuesOverride[name]
+                    ? fieldValuesOverride[name]
+                    : fieldValues[name]['values']
                 props['selected'] = fieldValues[name]['selected']
 
                 return (

--- a/src/components/FormBase/index.js
+++ b/src/components/FormBase/index.js
@@ -101,6 +101,7 @@ export class FormBase extends React.Component {
                 onChange={this.onChange}
                 changeContext={this.changeContext}
                 submitLabel={this.submitLabel}
+                fieldValuesOverride={this.fieldValuesOverride || {}}
                 onSubmit={this.onBeforeSubmit}
             />
         )

--- a/src/configureStore.js
+++ b/src/configureStore.js
@@ -5,9 +5,5 @@ import { composeWithDevTools } from 'redux-devtools-extension'
 
 export * from './reducers/user/actions'
 
-const store = createStore(
-    reducers,
-    composeWithDevTools(applyMiddleware(reduxThunk))
-)
-
-export { store }
+export const configureStore = () =>
+    createStore(reducers, composeWithDevTools(applyMiddleware(reduxThunk)))

--- a/src/helpers/api.js
+++ b/src/helpers/api.js
@@ -1,0 +1,33 @@
+const ATTRIBUTES_ENDPOINT = 'attributes.json'
+
+let d2
+let api
+
+/**
+ * Sets d2 and the api
+ */
+export const initApi = d2Instance => {
+    d2 = d2Instance
+    api = d2.Api.getApi()
+}
+
+export const getUniqueAttributes = ({ type }) => {
+    const params = [
+        `paging=false`,
+        `fields=${['id', 'displayName'].join(',')}`,
+        `filter=unique:eq:true`,
+        `filter=${type}Attribute:eq:true`,
+    ]
+
+    return api.get(`${ATTRIBUTES_ENDPOINT}?${params.join('&')}`)
+}
+
+export const getUniqueDataElementAttributes = () =>
+    getUniqueAttributes({ type: 'dataElement' })
+        .then(({ attributes }) => attributes)
+        .catch(() => [])
+
+export const getUniqueOrganisationUnitAttributes = () =>
+    getUniqueAttributes({ type: 'organisationUnit' })
+        .then(({ attributes }) => attributes)
+        .catch(() => [])

--- a/src/helpers/api.js
+++ b/src/helpers/api.js
@@ -31,3 +31,8 @@ export const getUniqueOrganisationUnitAttributes = () =>
     getUniqueAttributes({ type: 'organisationUnit' })
         .then(({ attributes }) => attributes)
         .catch(() => [])
+
+export const getUniqueCategoryAttributes = () =>
+    getUniqueAttributes({ type: 'categoryOptionCombo' })
+        .then(({ attributes }) => attributes)
+        .catch(() => [])

--- a/src/helpers/fields.js
+++ b/src/helpers/fields.js
@@ -28,7 +28,7 @@ const fields = {
     categoryOptionComboIdScheme: getField(
         'categoryOptionComboIdScheme',
         i18n.t('Category ID scheme'),
-        TYPE_RADIO,
+        TYPE_SELECT,
         CTX_MORE_OPTIONS
     ),
     children: getField('children', i18n.t('Children'), TYPE_RADIO),
@@ -42,7 +42,7 @@ const fields = {
     dataElementIdScheme: getField(
         'dataElementIdScheme',
         i18n.t('Data element ID scheme'),
-        TYPE_RADIO,
+        TYPE_SELECT,
         CTX_MORE_OPTIONS
     ),
     dryRun: getField('dryRun', i18n.t('Dry run'), TYPE_RADIO),
@@ -59,7 +59,12 @@ const fields = {
         CTX_MORE_OPTIONS
     ),
     format: getField('format', i18n.t('Format'), TYPE_RADIO),
-    idScheme: getField('idScheme', i18n.t('ID scheme'), TYPE_RADIO),
+    idScheme: getField(
+        'idScheme',
+        i18n.t('ID scheme'),
+        TYPE_SELECT,
+        CTX_MORE_OPTIONS
+    ),
     identifier: getField('identifier', i18n.t('Identifier'), TYPE_RADIO),
     importMode: getField('importMode', i18n.t('Dry run'), TYPE_RADIO),
     importReportMode: getField(
@@ -97,7 +102,7 @@ const fields = {
     orgUnitIdScheme: getField(
         'orgUnitIdScheme',
         i18n.t('Org unit ID scheme'),
-        TYPE_RADIO,
+        TYPE_SELECT,
         CTX_MORE_OPTIONS
     ),
     orgUnit_SingleSelect: getField(

--- a/src/helpers/values.js
+++ b/src/helpers/values.js
@@ -59,7 +59,7 @@ const calculated = {
     format: getFormat,
 }
 
-const values = {
+export const values = {
     upload: {
         selected: null,
     },
@@ -75,7 +75,6 @@ const values = {
             ['UID', i18n.t('UID')],
             ['CODE', i18n.t('Code')],
             ['NAME', i18n.t('Name')],
-            ['ATTRIBUTE:UKNKz1H10EE', i18n.t('HR identifier')],
         ]),
     },
 

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ import './locales'
 import './index.css'
 import App from './App'
 import { initApi } from './helpers/api'
-import { store } from './store'
+import { configureStore } from './configureStore'
 import { apiConfig } from 'config'
 import { init } from 'd2/lib/d2'
 
@@ -22,26 +22,26 @@ init({
         'X-Requested-With': 'XMLHttpRequest',
     },
 })
-  .then(initApi)
-  .then(() => {
-    lightBaseTheme.palette.primary1Color = '#4c708c'
-    lightBaseTheme.palette.primary2Color = '#4c708c'
-    lightBaseTheme.palette.primary3Color = '#4c708c'
-    lightBaseTheme.palette.pickerHeaderColor = '#4c708c'
+    .then(initApi)
+    .then(() => {
+        lightBaseTheme.palette.primary1Color = '#4c708c'
+        lightBaseTheme.palette.primary2Color = '#4c708c'
+        lightBaseTheme.palette.primary3Color = '#4c708c'
+        lightBaseTheme.palette.pickerHeaderColor = '#4c708c'
 
-    return getMuiTheme(lightBaseTheme)
-  })
-  .then(muiTheme => {
-    ReactDOM.render(
-      <Provider store={store}>
-        <MuiThemeProvider muiTheme={muiTheme}>
-          <HashRouter>
-            <App />
-          </HashRouter>
-        </MuiThemeProvider>
-      </Provider>,
-      document.getElementById('root')
-    )
-  })
+        return getMuiTheme(lightBaseTheme)
+    })
+    .then(muiTheme => {
+        const store = configureStore()
 
-
+        ReactDOM.render(
+            <Provider store={store}>
+                <MuiThemeProvider muiTheme={muiTheme}>
+                    <HashRouter>
+                        <App />
+                    </HashRouter>
+                </MuiThemeProvider>
+            </Provider>,
+            document.getElementById('root')
+        )
+    })

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,6 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import { Provider } from 'react-redux'
 import { HashRouter } from 'react-router-dom'
-
 import { MuiThemeProvider } from 'material-ui'
 import lightBaseTheme from 'material-ui/styles/baseThemes/lightBaseTheme'
 import getMuiTheme from 'material-ui/styles/getMuiTheme'
@@ -10,33 +9,39 @@ import getMuiTheme from 'material-ui/styles/getMuiTheme'
 import './locales'
 import './index.css'
 import App from './App'
-
+import { initApi } from './helpers/api'
 import { store } from './store'
-
 import { apiConfig } from 'config'
 import { init } from 'd2/lib/d2'
+
 const { server, version } = apiConfig
+
 init({
     baseUrl: `${server}/api/${version}`,
     headers: {
         'X-Requested-With': 'XMLHttpRequest',
     },
 })
+  .then(initApi)
+  .then(() => {
+    lightBaseTheme.palette.primary1Color = '#4c708c'
+    lightBaseTheme.palette.primary2Color = '#4c708c'
+    lightBaseTheme.palette.primary3Color = '#4c708c'
+    lightBaseTheme.palette.pickerHeaderColor = '#4c708c'
 
-lightBaseTheme.palette.primary1Color = '#4c708c'
-lightBaseTheme.palette.primary2Color = '#4c708c'
-lightBaseTheme.palette.primary3Color = '#4c708c'
-lightBaseTheme.palette.pickerHeaderColor = '#4c708c'
-
-const muiTheme = getMuiTheme(lightBaseTheme)
-
-ReactDOM.render(
-    <Provider store={store}>
+    return getMuiTheme(lightBaseTheme)
+  })
+  .then(muiTheme => {
+    ReactDOM.render(
+      <Provider store={store}>
         <MuiThemeProvider muiTheme={muiTheme}>
-            <HashRouter>
-                <App />
-            </HashRouter>
+          <HashRouter>
+            <App />
+          </HashRouter>
         </MuiThemeProvider>
-    </Provider>,
-    document.getElementById('root')
-)
+      </Provider>,
+      document.getElementById('root')
+    )
+  })
+
+

--- a/src/pages/export/Data.js
+++ b/src/pages/export/Data.js
@@ -1,3 +1,4 @@
+import { connect } from 'react-redux'
 import React from 'react'
 import i18n from '@dhis2/d2-i18n'
 import PropTypes from 'prop-types'
@@ -13,10 +14,16 @@ import {
     getFormFieldMoreOptions,
     getFormValues,
     getParamsFromFormState,
+    values,
 } from 'helpers'
 import { DataIcon } from 'components/Icon'
+import {
+    fetchUniqueDataElementAttributes,
+    fetchUniqueOrgUnitAttributes,
+} from '../../reducers/attributes/thunks'
+import s from '../../components/Form/styles.css'
 
-export class DataExport extends FormBase {
+class DataExport extends FormBase {
     static path = '/export/data'
 
     static order = 7
@@ -35,7 +42,6 @@ export class DataExport extends FormBase {
     formWidth = 800
     formTitle = i18n.t('Data Export')
     submitLabel = i18n.t('Export')
-
     fields = [
         ...getFormFields([
             'orgUnit',
@@ -56,7 +62,6 @@ export class DataExport extends FormBase {
             'categoryOptionComboIdScheme',
         ]),
     ]
-
     state = getFormValues([
         'orgUnit',
         'children',
@@ -72,7 +77,49 @@ export class DataExport extends FormBase {
     ])
 
     async componentDidMount() {
+        this.props.fetchDataElementAttributes()
+        this.props.fetchOrganisationUnitAttributes()
         await this.fetch()
+    }
+
+    componentDidUpdate(prevProps) {
+        // Only set field overrides if the amount of elements changed in the store
+        // These values will be loaded on page load only anyways
+        if (
+            prevProps.dataElementAttributes.length !==
+                this.props.dataElementAttributes.length ||
+            prevProps.orgUnitAttributes.length !==
+                this.props.orgUnitAttributes.length
+        ) {
+            // Collect default form options and add dynamic ones
+            const dataElementIdScheme = [
+                ...values.dataElementIdScheme.values,
+                ...this.props.dataElementAttributes.map(
+                    ({ id, displayName: label }) => ({
+                        value: `ATTRIBUTE:${id}`,
+                        label,
+                    })
+                ),
+            ]
+
+            const orgUnitIdScheme = [
+                ...values.orgUnitIdScheme.values,
+                ...this.props.orgUnitAttributes.map(
+                    ({ id, displayName: label }) => ({
+                        value: `ATTRIBUTE:${id}`,
+                        label,
+                    })
+                ),
+            ]
+
+            // Set the override values
+            // These will be used by the Form copmonent
+            // to build the input components
+            this.fieldValuesOverride = {
+                dataElementIdScheme,
+                orgUnitIdScheme,
+            }
+        }
     }
 
     async fetch() {
@@ -175,4 +222,44 @@ export class DataExport extends FormBase {
             console.log('Data Export error', e, '\n')
         }
     }
+  
+    render() {
+        const form = super.render()
+
+        if (this.props.loadingAttributes) {
+            return (
+                <div className={s.wrapper}>
+                    <div
+                        className={s.form}
+                        style={{
+                            padding: '14px 20px',
+                            width: 800,
+                            boxSizing: 'border-box',
+                            margin: '60px auto',
+                        }}
+                    >
+                        {i18n.t('Loading options...')}
+                    </div>
+                </div>
+            )
+        }
+
+        return form
+    }
 }
+
+const ConnectedDataExport = connect(
+    state => ({
+        loadingAttributes: state.attributes.loading,
+        dataElementAttributes: state.attributes.dataElement,
+        orgUnitAttributes: state.attributes.organisationUnit,
+    }),
+    dispatch => ({
+        fetchDataElementAttributes: () =>
+            dispatch(fetchUniqueDataElementAttributes()),
+        fetchOrganisationUnitAttributes: () =>
+            dispatch(fetchUniqueOrgUnitAttributes()),
+    })
+)(DataExport)
+
+export { ConnectedDataExport as DataExport }

--- a/src/pages/import/Data.js
+++ b/src/pages/import/Data.js
@@ -1,3 +1,4 @@
+import { connect } from 'react-redux'
 import React from 'react'
 import i18n from '@dhis2/d2-i18n'
 import { apiConfig } from 'config'
@@ -9,10 +10,21 @@ import {
     getFormValues,
     getParamsFromFormState,
     getUploadXHR,
+    values,
 } from 'helpers'
 import { fetchLog } from './helpers'
 
-export class DataImport extends FormBase {
+import {
+    fetchUniqueDataElementAttributes,
+    fetchUniqueOrgUnitAttributes,
+} from '../../reducers/attributes/thunks'
+import {
+    getSharedAttributes,
+    getSharedAttributesLoading,
+} from '../../reducers/attributes/selectors'
+import s from '../../components/Form/styles.css'
+
+class DataImport extends FormBase {
     static path = '/import/data'
 
     static order = 2
@@ -60,7 +72,74 @@ export class DataImport extends FormBase {
     ])
 
     async componentDidMount() {
+        // creating default props here because componentDidUpdate
+        // will not be called on initial render
+        this.computeFieldOverrideValues({
+            dataElementAttributes: [],
+            orgUnitAttributes: [],
+        })
+        this.props.fetchDataElementAttributes()
+        this.props.fetchOrganisationUnitAttributes()
         await fetchLog('', 'DATAVALUE_IMPORT')
+    }
+
+    componentDidUpdate(prevProps) {
+        this.computeFieldOverrideValues(prevProps)
+    }
+
+    computeFieldOverrideValues(prevProps) {
+        // Only set field overrides if the amount of elements changed in the store
+        // These values will be loaded on page load only anyways
+        if (
+            prevProps.dataElementAttributes.length !==
+                this.props.dataElementAttributes.length ||
+            prevProps.orgUnitAttributes.length !==
+                this.props.orgUnitAttributes.length
+        ) {
+            // Collect default form options and add dynamic ones
+            const dataElementIdScheme = [
+                ...values.dataElementIdScheme.values,
+                ...this.props.dataElementAttributes.map(
+                    ({ id, displayName: label }) => ({
+                        value: `ATTRIBUTE:${id}`,
+                        label,
+                    })
+                ),
+            ]
+
+            const orgUnitIdScheme = [
+                ...values.orgUnitIdScheme.values,
+                ...this.props.orgUnitAttributes.map(
+                    ({ id, displayName: label }) => ({
+                        value: `ATTRIBUTE:${id}`,
+                        label,
+                    })
+                ),
+            ]
+
+            const idScheme = [
+                ...values.idScheme.values,
+                ...this.props.sharedAttributes.map(
+                    ({ id, displayName: label }) => ({
+                        value: `ATTRIBUTE:${id}`,
+                        label,
+                    })
+                ),
+            ]
+
+            // Set the override values
+            // These will be used by the Form copmonent
+            // to build the input components
+            // NOTE: this.forceUpdate() wouldn't be needed
+            // if "idScheme" was hidden before clicking on "more options"
+            // Due to that bug.. We have to force an update after this
+            this.fieldValuesOverride = {
+                dataElementIdScheme,
+                orgUnitIdScheme,
+                idScheme,
+            }
+            this.forceUpdate()
+        }
     }
 
     onSubmit = () => {
@@ -104,4 +183,45 @@ export class DataImport extends FormBase {
             console.log('Data Import error', e, '\n')
         }
     }
+
+    render() {
+        const form = super.render()
+
+        if (this.props.loadingAttributes) {
+            return (
+                <div className={s.wrapper}>
+                    <div
+                        className={s.form}
+                        style={{
+                            padding: '14px 20px',
+                            width: 800,
+                            boxSizing: 'border-box',
+                            margin: '60px auto',
+                        }}
+                    >
+                        {i18n.t('Loading options...')}
+                    </div>
+                </div>
+            )
+        }
+
+        return form
+    }
 }
+
+const ConnectedDataImport = connect(
+    state => ({
+        loadingAttributes: getSharedAttributesLoading(state),
+        dataElementAttributes: state.attributes.dataElement.data,
+        orgUnitAttributes: state.attributes.organisationUnit.data,
+        sharedAttributes: getSharedAttributes(state),
+    }),
+    dispatch => ({
+        fetchDataElementAttributes: () =>
+            dispatch(fetchUniqueDataElementAttributes()),
+        fetchOrganisationUnitAttributes: () =>
+            dispatch(fetchUniqueOrgUnitAttributes()),
+    })
+)(DataImport)
+
+export { ConnectedDataImport as DataImport }

--- a/src/reducers/attributes/__test__/selectors.test.js
+++ b/src/reducers/attributes/__test__/selectors.test.js
@@ -1,0 +1,75 @@
+import { getSharedAttributes, getSharedAttributesLoading } from '../selectors'
+
+describe('Selector - Attributes - getSharedAttributes', () => {
+    const hrIdentifier = {
+        id: 'UKNKz1H10EE',
+        displayName: 'HR identifier',
+    }
+
+    const keCode = {
+        id: 'l1VmqIHKk6t',
+        displayName: 'KE code',
+    }
+
+    it('should return the hrIdentifier attribute when it is found both in data elements and org unit attributes', () => {
+        const state = {
+            attributes: {
+                dataElement: { data: [hrIdentifier] },
+                organisationUnit: { data: [hrIdentifier, keCode] },
+            },
+        }
+
+        expect(getSharedAttributes(state)).toEqual([
+            {
+                id: 'UKNKz1H10EE',
+                displayName: 'HR identifier',
+            },
+        ])
+    })
+
+    it('should return an empty array when no common attributes are found in both data elements and org unit attributes', () => {
+        const state = {
+            attributes: {
+                dataElement: { data: [] },
+                organisationUnit: { data: [hrIdentifier, keCode] },
+            },
+        }
+
+        expect(getSharedAttributes(state)).toEqual([])
+    })
+})
+
+describe('Selector - Attributes - getSharedAttributesLoading', () => {
+    it('should return true when all loading states are true', () => {
+        const state = {
+            attributes: {
+                dataElement: { loading: true },
+                organisationUnit: { loading: true },
+            },
+        }
+
+        expect(getSharedAttributesLoading(state)).toBe(true)
+    })
+
+    it('should return true when one loading state is true', () => {
+        const state = {
+            attributes: {
+                dataElement: { loading: true },
+                organisationUnit: { loading: false },
+            },
+        }
+
+        expect(getSharedAttributesLoading(state)).toBe(true)
+    })
+
+    it('should return false when no loading state is true', () => {
+        const state = {
+            attributes: {
+                dataElement: { loading: false },
+                organisationUnit: { loading: false },
+            },
+        }
+
+        expect(getSharedAttributesLoading(state)).toBe(false)
+    })
+})

--- a/src/reducers/attributes/__test__/thunks.test.js
+++ b/src/reducers/attributes/__test__/thunks.test.js
@@ -1,0 +1,181 @@
+import configureMockStore from 'redux-mock-store'
+import thunk from 'redux-thunk'
+
+import {
+    loadingAttributesError,
+    loadingAttributesStart,
+    setAttribute,
+} from '../actions'
+
+import {
+    fetchUniqueDataElementAttributes,
+    fetchUniqueOrgUnitAttributes,
+    fetchUniqueCategoryAttributes,
+} from '../thunks'
+
+import {
+    getUniqueDataElementAttributes,
+    getUniqueOrganisationUnitAttributes,
+    getUniqueCategoryAttributes,
+} from '../../../helpers/api'
+
+jest.mock('../../../helpers/api', () => ({
+    getUniqueDataElementAttributes: jest.fn(() => Promise.resolve()),
+    getUniqueOrganisationUnitAttributes: jest.fn(() => Promise.resolve()),
+    getUniqueCategoryAttributes: jest.fn(() => Promise.resolve()),
+}))
+
+export const mockStore = configureMockStore([thunk])
+
+describe('Thunks - Attributes', () => {
+    const store = mockStore({})
+
+    const hrIdentifier = {
+        id: 'UKNKz1H10EE',
+        displayName: 'HR identifier',
+    }
+
+    const keCode = {
+        id: 'l1VmqIHKk6t',
+        displayName: 'KE code',
+    }
+
+    afterEach(() => {
+        store.clearActions()
+        getUniqueDataElementAttributes.mockClear()
+        getUniqueOrganisationUnitAttributes.mockClear()
+        getUniqueCategoryAttributes.mockClear()
+    })
+
+    describe('fetchUniqueDataElementAttributes', () => {
+        it('should dispatch a loading start action when loading the data element attributes', () => {
+            const expectedActions = expect.arrayContaining([
+                loadingAttributesStart('dataElement'),
+            ])
+
+            store.dispatch(fetchUniqueDataElementAttributes()).then(() => {
+                expect(store.getActions()).toEqual(expectedActions)
+            })
+        })
+
+        it('should dispatch a success action with the attributes when loading data element attributes successfully', () => {
+            const dataElementAttributes = [hrIdentifier]
+
+            const expectedActions = expect.arrayContaining([
+                setAttribute('dataElement', dataElementAttributes),
+            ])
+
+            getUniqueDataElementAttributes.mockImplementationOnce(() =>
+                Promise.resolve(dataElementAttributes)
+            )
+
+            store.dispatch(fetchUniqueDataElementAttributes()).then(() => {
+                expect(store.getActions()).toEqual(expectedActions)
+            })
+        })
+
+        it('should dispatch an error action with the error when loading data element attributes fails', () => {
+            const error = new Error('Oops')
+
+            const expectedActions = expect.arrayContaining([
+                loadingAttributesError('dataElement', error.message),
+            ])
+
+            getUniqueDataElementAttributes.mockImplementationOnce(() =>
+                Promise.reject(error)
+            )
+
+            store.dispatch(fetchUniqueDataElementAttributes()).then(() => {
+                expect(store.getActions()).toEqual(expectedActions)
+            })
+        })
+    })
+
+    describe('fetchUniqueOrgUnitAttributes', () => {
+        it('should dispatch a loading start action when loading the organisation unit attributes', () => {
+            const expectedActions = expect.arrayContaining([
+                loadingAttributesStart('organisationUnit'),
+            ])
+
+            store.dispatch(fetchUniqueOrgUnitAttributes()).then(() => {
+                expect(store.getActions()).toEqual(expectedActions)
+            })
+        })
+
+        it('should dispatch a success action with the attributes when loading organisation unit attributes successfully', () => {
+            const organisationUnitAttributes = [hrIdentifier]
+
+            const expectedActions = expect.arrayContaining([
+                setAttribute('organisationUnit', organisationUnitAttributes),
+            ])
+
+            getUniqueOrganisationUnitAttributes.mockImplementationOnce(() =>
+                Promise.resolve(organisationUnitAttributes)
+            )
+
+            store.dispatch(fetchUniqueOrgUnitAttributes()).then(() => {
+                expect(store.getActions()).toEqual(expectedActions)
+            })
+        })
+
+        it('should dispatch an error action with the error when loading organisation unit attributes fails', () => {
+            const error = new Error('Oops')
+
+            const expectedActions = expect.arrayContaining([
+                loadingAttributesError('organisationUnit', error.message),
+            ])
+
+            getUniqueOrganisationUnitAttributes.mockImplementationOnce(() =>
+                Promise.reject(error)
+            )
+
+            store.dispatch(fetchUniqueOrgUnitAttributes()).then(() => {
+                expect(store.getActions()).toEqual(expectedActions)
+            })
+        })
+    })
+
+    describe('fetchUniqueCategoryAttributes', () => {
+        it('should dispatch a loading start action when loading the category attributes', () => {
+            const expectedActions = expect.arrayContaining([
+                loadingAttributesStart('category'),
+            ])
+
+            store.dispatch(fetchUniqueCategoryAttributes()).then(() => {
+                expect(store.getActions()).toEqual(expectedActions)
+            })
+        })
+
+        it('should dispatch a success action with the attributes when loading category attributes successfully', () => {
+            const categoryAttributes = [hrIdentifier]
+
+            const expectedActions = expect.arrayContaining([
+                setAttribute('category', categoryAttributes),
+            ])
+
+            getUniqueCategoryAttributes.mockImplementationOnce(() =>
+                Promise.resolve(categoryAttributes)
+            )
+
+            store.dispatch(fetchUniqueCategoryAttributes()).then(() => {
+                expect(store.getActions()).toEqual(expectedActions)
+            })
+        })
+
+        it('should dispatch an error action with the error when loading category attributes fails', () => {
+            const error = new Error('Oops')
+
+            const expectedActions = expect.arrayContaining([
+                loadingAttributesError('category', error.message),
+            ])
+
+            getUniqueCategoryAttributes.mockImplementationOnce(() =>
+                Promise.reject(error)
+            )
+
+            store.dispatch(fetchUniqueCategoryAttributes()).then(() => {
+                expect(store.getActions()).toEqual(expectedActions)
+            })
+        })
+    })
+})

--- a/src/reducers/attributes/actions.js
+++ b/src/reducers/attributes/actions.js
@@ -1,0 +1,33 @@
+export const LOADING_ATTRIBUTES_START = 'LOADING_ATTRIBUTES_START'
+export const LOADING_ATTRIBUTES_ERROR = 'LOADING_ATTRIBUTES_ERROR'
+export const SET_ATTRIBUTES = 'SET_ATTRIBUTES'
+
+/**
+ * @param {string} type
+ * @returns {Object}
+ */
+export const loadingAttributesStart = type => ({
+    type: LOADING_ATTRIBUTES_START,
+    payload: type,
+})
+
+/**
+ * @param {string} type
+ * @param {string} message
+ */
+export const loadingAttributesError = (type, error) => ({
+    type: LOADING_ATTRIBUTES_ERROR,
+    payload: { type, error },
+})
+
+/**
+ * @param {string} type
+ * @param {Object} attributes
+ * @param {string} attributes.id
+ * @param {string} attributes.displayName
+ * @returns {Object}
+ */
+export const setAttribute = (type, attributes) => ({
+    type: SET_ATTRIBUTES,
+    payload: { type, attributes },
+})

--- a/src/reducers/attributes/index.js
+++ b/src/reducers/attributes/index.js
@@ -1,0 +1,70 @@
+import {
+    LOADING_ATTRIBUTES_ERROR,
+    LOADING_ATTRIBUTES_START,
+    SET_ATTRIBUTES,
+} from './actions'
+
+const initialState = {
+    dataElement: {
+        loading: false,
+        loaded: false,
+        error: '',
+        data: [],
+    },
+
+    organisationUnit: {
+        loading: false,
+        loaded: false,
+        error: '',
+        data: [],
+    },
+
+    category: {
+        loading: false,
+        loaded: false,
+        error: '',
+        data: [],
+    },
+}
+
+export default function attributesReducer(
+    state = initialState,
+    { type, payload } = {}
+) {
+    if (type === LOADING_ATTRIBUTES_START) {
+        return {
+            ...state,
+            [payload]: {
+                ...state[payload],
+                loading: true,
+                loaded: false,
+                error: '',
+            },
+        }
+    }
+
+    if (type === LOADING_ATTRIBUTES_ERROR) {
+        return {
+            ...state,
+            [payload.type]: {
+                ...state[payload.type],
+                loading: false,
+                error: payload.message,
+            },
+        }
+    }
+
+    if (type === SET_ATTRIBUTES) {
+        return {
+            ...state,
+            [payload.type]: {
+                ...state[payload.type],
+                data: payload.attributes,
+                loading: false,
+                loaded: true,
+            },
+        }
+    }
+
+    return state
+}

--- a/src/reducers/attributes/selectors.js
+++ b/src/reducers/attributes/selectors.js
@@ -1,0 +1,40 @@
+import { createSelector } from 'reselect'
+
+const attributeFoundIn = (attribute, collection) =>
+    !!collection.find(({ id }) => id === attribute.id)
+
+export const getDataElementAttributes = state =>
+    state.attributes.dataElement.data
+
+export const getDataElementAttributesLoading = state =>
+    state.attributes.dataElement.loading
+
+export const getOrgUnitAttributes = state =>
+    state.attributes.organisationUnit.data
+
+export const getOrgUnitAttributesLoading = state =>
+    state.attributes.organisationUnit.loading
+
+export const getCategoryAttributes = state => state.attributes.category.data
+
+export const getCateboryAttributesLoading = state =>
+    state.attributes.category.loading
+
+export const getSharedAttributes = createSelector(
+    [getDataElementAttributes, getOrgUnitAttributes],
+    (dataElementAttributes, orgUnitAttributes) =>
+        dataElementAttributes.reduce((shared, attribute) => {
+            const foundInOrgUnits = attributeFoundIn(
+                attribute,
+                orgUnitAttributes
+            )
+
+            return foundInOrgUnits ? [...shared, attribute] : shared
+        }, [])
+)
+
+export const getSharedAttributesLoading = createSelector(
+    [getDataElementAttributesLoading, getOrgUnitAttributesLoading],
+    (dataElementAttributesLoading, orgUnitAttributesLoading) =>
+        dataElementAttributesLoading || orgUnitAttributesLoading
+)

--- a/src/reducers/attributes/thunks.js
+++ b/src/reducers/attributes/thunks.js
@@ -1,0 +1,42 @@
+import {
+    getUniqueDataElementAttributes,
+    getUniqueOrganisationUnitAttributes,
+    getUniqueCategoryAttributes,
+} from '../../helpers/api'
+import {
+    loadingAttributesError,
+    loadingAttributesStart,
+    setAttribute,
+} from './actions'
+
+export const fetchUniqueDataElementAttributes = () => dispatch => {
+    dispatch(loadingAttributesStart('dataElement'))
+
+    return getUniqueDataElementAttributes()
+        .then(attributes => dispatch(setAttribute('dataElement', attributes)))
+        .catch(error =>
+            dispatch(loadingAttributesError('dataElement', error.message))
+        )
+}
+
+export const fetchUniqueOrgUnitAttributes = () => dispatch => {
+    dispatch(loadingAttributesStart('organisationUnit'))
+
+    return getUniqueOrganisationUnitAttributes()
+        .then(attributes =>
+            dispatch(setAttribute('organisationUnit', attributes))
+        )
+        .catch(error =>
+            dispatch(loadingAttributesError('organisationUnit', error.message))
+        )
+}
+
+export const fetchUniqueCategoryAttributes = () => dispatch => {
+    dispatch(loadingAttributesStart('category'))
+
+    return getUniqueCategoryAttributes()
+        .then(attributes => dispatch(setAttribute('category', attributes)))
+        .catch(error =>
+            dispatch(loadingAttributesError('category', error.message))
+        )
+}

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -2,10 +2,14 @@ import { combineReducers } from 'redux'
 
 import user from './user'
 import schemas from './schemas'
+import attributes from './attributes'
+
 export * from 'reducers/user/actions'
 export * from 'reducers/schemas/actions'
+export * from './attributes/actions'
 
 export default combineReducers({
     user,
     schemas,
+    attributes,
 })

--- a/src/store.js
+++ b/src/store.js
@@ -1,10 +1,13 @@
-import { createStore } from 'redux'
+import { createStore, applyMiddleware } from 'redux'
 import reducers from './reducers'
+import reduxThunk from 'redux-thunk'
+import { composeWithDevTools } from 'redux-devtools-extension'
 
 export * from './reducers/user/actions'
 
 const store = createStore(
     reducers,
-    window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
+    composeWithDevTools(applyMiddleware(reduxThunk))
 )
+
 export { store }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6727,7 +6727,7 @@ lodash.isequal@^3.0:
     lodash._baseisequal "^3.0.0"
     lodash._bindcallback "^3.0.0"
 
-lodash.isplainobject@^4.0.3:
+lodash.isplainobject@^4.0.3, lodash.isplainobject@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
   integrity sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=
@@ -9037,6 +9037,13 @@ reduce-function-call@^1.0.1:
   integrity sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=
   dependencies:
     balanced-match "^0.4.2"
+
+redux-mock-store@^1.5.4:
+  version "1.5.4"
+  resolved "https://registry.yarnpkg.com/redux-mock-store/-/redux-mock-store-1.5.4.tgz#90d02495fd918ddbaa96b83aef626287c9ab5872"
+  integrity sha512-xmcA0O/tjCLXhh9Fuiq6pMrJCwFRaouA8436zcikdIpYWWCjU76CRk+i2bHx8EeiSiMGnB85/lZdU3wIJVXHTA==
+  dependencies:
+    lodash.isplainobject "^4.0.6"
 
 redux@^3.7.2:
   version "3.7.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9038,12 +9038,22 @@ reduce-function-call@^1.0.1:
   dependencies:
     balanced-match "^0.4.2"
 
+redux-devtools-extension@^2.13.8:
+  version "2.13.8"
+  resolved "https://registry.yarnpkg.com/redux-devtools-extension/-/redux-devtools-extension-2.13.8.tgz#37b982688626e5e4993ff87220c9bbb7cd2d96e1"
+  integrity sha512-8qlpooP2QqPtZHQZRhx3x3OP5skEV1py/zUdMY28WNAocbafxdG2tRD1MWE7sp8obGMNYuLWanhhQ7EQvT1FBg==
+
 redux-mock-store@^1.5.4:
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/redux-mock-store/-/redux-mock-store-1.5.4.tgz#90d02495fd918ddbaa96b83aef626287c9ab5872"
   integrity sha512-xmcA0O/tjCLXhh9Fuiq6pMrJCwFRaouA8436zcikdIpYWWCjU76CRk+i2bHx8EeiSiMGnB85/lZdU3wIJVXHTA==
   dependencies:
     lodash.isplainobject "^4.0.6"
+
+redux-thunk@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"
+  integrity sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw==
 
 redux@^3.7.2:
   version "3.7.2"


### PR DESCRIPTION
Fixes DHIS2-6991 for v32

This is a backport for offering attribute options in the id scheme field when they're shared between data element id scheme and org unit id scheme (which means they have to be unique as well).

Seems to be working from my perspective (the only way to really test it for me is to check if the same/correct values are being sent).

I also had to modify the data import page which is different from v33/v34 as the later version already use RFF