### PR TITLE
chore(deps): remove unused url-join dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,7 @@
     "redux-devtools-extension": "^2.13.8",
     "redux-thunk": "^2.3.0",
     "reselect": "^4.0.0",
-    "typeface-roboto": "^0.0.54",
-    "url-join": "^4.0.1"
+    "typeface-roboto": "^0.0.54"
   },
   "devDependencies": {
     "@babel/helper-create-regexp-features-plugin": "^7.7.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13087,11 +13087,6 @@ urix@^0.1.0:
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
 
-url-join@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/url-join/-/url-join-4.0.1.tgz#b642e21a2646808ffa178c4c5fda39844e12cde7"
-  integrity sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==
-
 url-loader@1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/url-loader/-/url-loader-1.1.2.tgz#b971d191b83af693c5e3fea4064be9e1f2d7f8d8"


### PR DESCRIPTION
Related to: https://jira.dhis2.org/browse/DHIS2-8082. Removing since it doesn't seem like it's used anymore.