### PR TITLE
fix: overwrite default error message only when a response message exists

### DIFF
--- a/src/pages/import/MetaData/helper.js
+++ b/src/pages/import/MetaData/helper.js
@@ -142,7 +142,10 @@ export const onSubmit = (setLoading, setError) => values => {
 
                 try {
                     const response = JSON.parse(e.target.response)
-                    message = response.message
+
+                    if (response.message) {
+                        message = response.message
+                    }
                 } catch (e2) {}
 
                 setError(message)


### PR DESCRIPTION
Previously, when the api responded with a 5xx status code, there was no message property on the response, so the default error message was overwritten with `undefined` which made the app think that there is no error, so it didn't show anything.