### PR TITLE
fix: overwrite default error message only when a response message exists

### DIFF
--- a/src/pages/import/MetaData/helper.js
+++ b/src/pages/import/MetaData/helper.js
@@ -142,7 +142,10 @@ export const onSubmit = (setLoading, setError) => values => {
 
                 try {
                     const response = JSON.parse(e.target.response)
-                    message = response.message
+
+                    if (response.message) {
+                        message = response.message
+                    }
                 } catch (e2) {}
 
                 setError(message)


### PR DESCRIPTION
This is a backport of #497. @vilkg approved backporting this during the hard freeze