### PR TITLE
chore(deploy): fix deploy-build to upload the correct directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ script:
     - npm run build
 deploy:
     - provider: script
-      script: npx --package @dhis2/deploy-build deploy-build
+      script: npx --package @dhis2/deploy-build deploy-build d2-ci build/app
       skip_cleanup: true
       on:
           all_branches: true


### PR DESCRIPTION
deploy-build uploads the `build` directory by default, but for App Platform apps it needs to upload `build/app` - see https://github.com/dhis2/data-visualizer-app/blob/master/.travis.yml#L14