### PR TITLE
fix: TEI export format

### DIFF
--- a/src/components/Inputs/ProgramStatus.js
+++ b/src/components/Inputs/ProgramStatus.js
@@ -4,7 +4,7 @@ import i18n from '@dhis2/d2-i18n'
 import { RadioGroupField } from '../index'
 
 const programStatusOptions = [
-    { value: 'ALL', label: i18n.t('All') },
+    { value: '', label: i18n.t('All') },
     { value: 'ACTIVE', label: i18n.t('Active') },
     { value: 'COMPLETED', label: i18n.t('Completed') },
     { value: 'CANCELLED', label: i18n.t('Cancelled') },

--- a/src/pages/TEIExport/form-helper.js
+++ b/src/pages/TEIExport/form-helper.js
@@ -39,6 +39,7 @@ const minimizeParams = ({
     lastUpdatedDuration,
 }) => {
     const minParams = {
+        id: format.value.toLowerCase(),
         ou: selectedOrgUnits.map(o => pathToId(o)).join(';'),
         ouMode: ouMode.value,
         format: format.value,
@@ -96,9 +97,11 @@ const minimizeParams = ({
     return minParams
 }
 
+// HACK: this endpoint does not respect the 'format' parameter
 const teiQuery = {
     sets: {
-        resource: 'trackedEntityInstances',
+        resource: '/',
+        id: ({ id }) => `trackedEntityInstances.${id}`,
         params: x => x,
     },
 }

--- a/src/pages/TEIExport/form-helper.js
+++ b/src/pages/TEIExport/form-helper.js
@@ -57,7 +57,11 @@ const minimizeParams = ({
 
     if (teiTypeFilter.value == 'PROGRAM') {
         minParams.program = selectedPrograms[0]
-        minParams.programStatus = programStatus.value
+        if (minParams.programStatus) {
+            // programStatus = ALL is now the same
+            // as not providing a value for this param at all
+            minParams.programStatus = programStatus.value
+        }
         minParams.followUpStatus = followUpStatus.value
 
         if (programStartDate) {


### PR DESCRIPTION
The trackedEntityInstances endpoint does not respect the `format`
parameter and requires us to append the format to the resource name
when making the request.

Addresses:
- DHIS2-9404 (Missing format extension in the TEI export url)
- DHIS2-9403 (Malformed URL when exporting teis with programStatus=ALL)