### PR TITLE
fix(i18n): correctly import translations

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { HashRouter } from 'react-router-dom'
-import i18n from '@dhis2/d2-i18n'
+import i18n from './locales'
 import { CssReset, CircularLoader, ScreenCover } from '@dhis2/ui-core'
 
 import { TaskContext } from './contexts/'


### PR DESCRIPTION
Forgot to import from `./locales`.

Addresses:
- DHIS2-9402 (Translations are not supported in import-export app)