### PR TITLE
fix: sync tracked entity instance import

### DIFF
--- a/src/components/JobSummary/Summary/Summary.js
+++ b/src/components/JobSummary/Summary/Summary.js
@@ -30,7 +30,10 @@ const Summary = ({ summary }) => {
         }
         const { stats, messages } = typeReportParse(summary.typeReports)
         return (
-            <div data-test="job-summary-summary">
+            <div
+                data-test="job-summary-summary"
+                className={styles.typeReportSummary}
+            >
                 <TypeReportSummary
                     overviewStats={overviewStats}
                     stats={stats}

--- a/src/components/JobSummary/Summary/Summary.module.css
+++ b/src/components/JobSummary/Summary/Summary.module.css
@@ -4,7 +4,7 @@
     margin-bottom: 15px;
 }
 
-.rest {
+.rest, .typeReportSummary {
     max-height: 440px;
     overflow: auto;
     margin-bottom: 15px;

--- a/src/components/JobSummary/__test__/__snapshots__/JobSummary.test.js.snap
+++ b/src/components/JobSummary/__test__/__snapshots__/JobSummary.test.js.snap
@@ -74,6 +74,7 @@ exports[`summary for a GML job matches snapshot 1`] = `
       data-test="dhis2-uicore-divider"
     />
     <div
+      class="typeReportSummary"
       data-test="job-summary-summary"
     >
       <div>

--- a/src/components/JobSummary/__test__/__snapshots__/Summary.test.js.snap
+++ b/src/components/JobSummary/__test__/__snapshots__/Summary.test.js.snap
@@ -456,6 +456,7 @@ exports[`different job type summaries matches snapshot - EVENT_IMPORT 1`] = `
 exports[`different job type summaries matches snapshot - GML_IMPORT 1`] = `
 <DocumentFragment>
   <div
+    class="typeReportSummary"
     data-test="job-summary-summary"
   >
     <div>

--- a/src/utils/xhr.js
+++ b/src/utils/xhr.js
@@ -66,17 +66,31 @@ const extractIdAndMessage = xhr => {
     }
 
     if (typeof response !== 'undefined') {
-        return {
-            id: response.id,
-            msg: {
-                id: 'init',
-                text: message,
-                date: new Date(response.created),
-            },
+        if (response.id) {
+            // the response will contain an `id` if the import was asynchronous
+            return {
+                id: response.id,
+                msg: {
+                    id: 'init',
+                    text: message,
+                    date: new Date(response.created),
+                },
+            }
+        } else {
+            // the response will contain a report inside the response if the
+            // import was synchronous
+            return {
+                msg: {
+                    id: 'completed',
+                    text: 'Import:Done',
+                    date: new Date(),
+                },
+                typeReports: response,
+            }
         }
     }
 
-    // sync metadata, tei import
+    // sync metadata import
     if (typeReports) {
         if (
             Array.isArray(typeReports) &&


### PR DESCRIPTION
Fixes synchronous tracked entity instances import.
Also limit the max height of type report messages; apparently this can contain thousands of messages.

### Explanation
Synchronous tracked entity instances imports return a report inside the `response` property and not the `typeReports` property.