### PR TITLE
feat(export): disable export button while content is loading

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-09-10T10:48:32.415Z\n"
-"PO-Revision-Date: 2020-09-10T10:48:32.415Z\n"
+"POT-Creation-Date: 2020-09-11T12:57:56.718Z\n"
+"PO-Revision-Date: 2020-09-11T12:57:56.718Z\n"
 
 msgid "Something went wrong when loading the current user!"
 msgstr ""
@@ -134,6 +134,9 @@ msgid "Code"
 msgstr ""
 
 msgid "Event ID scheme"
+msgstr ""
+
+msgid "Loading export..."
 msgstr ""
 
 msgid "Select a file to import values from"

--- a/src/components/Inputs/ExportButton.js
+++ b/src/components/Inputs/ExportButton.js
@@ -1,19 +1,26 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import i18n from '@dhis2/d2-i18n'
 import { Button } from '@dhis2/ui'
 
 const DATATEST = 'input-export-submit'
 
-const ExportButton = ({ label }) => (
+const ExportButton = ({ label, disabledLabel, disabled }) => (
     <div style={{ marginBottom: 'var(--spacers-dp24)' }}>
-        <Button primary type="submit" dataTest={DATATEST}>
-            {label}
+        <Button primary type="submit" dataTest={DATATEST} disabled={disabled}>
+            {disabled ? disabledLabel : label}
         </Button>
     </div>
 )
 
+ExportButton.defaultProps = {
+    disabledLabel: i18n.t('Loading export...'),
+}
+
 ExportButton.propTypes = {
     label: PropTypes.string.isRequired,
+    disabled: PropTypes.bool,
+    disabledLabel: PropTypes.string,
 }
 
 export { ExportButton }

--- a/src/pages/DataExport/DataExport.js
+++ b/src/pages/DataExport/DataExport.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { useConfig } from '@dhis2/app-runtime'
 import i18n from '@dhis2/d2-i18n'
 import { ReactFinalForm } from '@dhis2/ui'
@@ -63,8 +63,9 @@ const initialValues = {
 }
 
 const DataExport = () => {
+    const [exportEnabled, setExportEnabled] = useState(true)
     const { baseUrl } = useConfig()
-    const onSubmit = onExport(baseUrl)
+    const onSubmit = onExport(baseUrl, setExportEnabled)
 
     return (
         <Page
@@ -101,7 +102,10 @@ const DataExport = () => {
                                 <IdScheme />
                             </SchemeContainer>
                         </MoreOptions>
-                        <ExportButton label={i18n.t('Export data')} />
+                        <ExportButton
+                            label={i18n.t('Export data')}
+                            disabled={!exportEnabled}
+                        />
                         <FormAlerts alerts={submitError} />
                     </form>
                 )}

--- a/src/pages/DataExport/form-helper.js
+++ b/src/pages/DataExport/form-helper.js
@@ -28,6 +28,7 @@ const valuesToParams = ({
     idScheme,
 }) =>
     [
+        `download=true`,
         `dataElementIdScheme=${dataElementIdScheme}`,
         `orgUnitIdScheme=${orgUnitIdScheme}`,
         `idScheme=${idScheme}`,
@@ -41,7 +42,9 @@ const valuesToParams = ({
         `compression=${compressionToName(compression)}`,
     ].join('&')
 
-const onExport = baseUrl => async values => {
+const onExport = (baseUrl, setExportEnabled) => async values => {
+    setExportEnabled(false)
+
     const { format, compression } = values
 
     const apiBaseUrl = `${baseUrl}/api/`
@@ -52,6 +55,7 @@ const onExport = baseUrl => async values => {
     // if compression is set we can redirect to the appropriate URL
     // and set the compression parameter
     if (compression) {
+        setTimeout(() => setExportEnabled(true), 5000)
         locationAssign(url)
         return
     }
@@ -60,6 +64,7 @@ const onExport = baseUrl => async values => {
     try {
         const data = await fetch(url, {
             Accept: getMimeType(format),
+            credentials: 'include',
         })
         const dataStr = await data.text()
         const filename = `data.${format}`
@@ -78,6 +83,8 @@ const onExport = baseUrl => async values => {
         console.error('DataExport onExport error: ', error)
 
         return { [FORM_ERROR]: errors }
+    } finally {
+        setExportEnabled(true)
     }
 }
 

--- a/src/pages/EventExport/EventExport.js
+++ b/src/pages/EventExport/EventExport.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { useConfig } from '@dhis2/app-runtime'
 import i18n from '@dhis2/d2-i18n'
 import { ReactFinalForm } from '@dhis2/ui'
@@ -65,8 +65,9 @@ const initialValues = {
 }
 
 const EventExport = () => {
+    const [exportEnabled, setExportEnabled] = useState(true)
     const { baseUrl } = useConfig()
-    const onSubmit = onExport(baseUrl)
+    const onSubmit = onExport(baseUrl, setExportEnabled)
 
     return (
         <Page
@@ -107,7 +108,10 @@ const EventExport = () => {
                                 <IdScheme />
                             </SchemeContainer>
                         </MoreOptions>
-                        <ExportButton label={i18n.t('Export events')} />
+                        <ExportButton
+                            label={i18n.t('Export events')}
+                            disabled={!exportEnabled}
+                        />
                     </form>
                 )}
             />

--- a/src/pages/EventExport/form-helper.js
+++ b/src/pages/EventExport/form-helper.js
@@ -5,7 +5,9 @@ import {
     DATE_AFTER_VALIDATOR,
 } from '../../components/DatePicker/DatePickerField'
 
-const onExport = baseUrl => values => {
+const onExport = (baseUrl, setExportEnabled) => values => {
+    setExportEnabled(false)
+
     const {
         selectedOrgUnits,
         selectedPrograms,
@@ -45,6 +47,8 @@ const onExport = baseUrl => values => {
         .filter(s => s != '')
         .join('&')
     const url = `${apiBaseUrl}${endpoint}.${endpointExtension}?${downloadUrlParams}`
+
+    setTimeout(() => setExportEnabled(true), 5000)
     locationAssign(url)
 }
 

--- a/src/pages/MetadataDependencyExport/MetadataDependencyExport.js
+++ b/src/pages/MetadataDependencyExport/MetadataDependencyExport.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { useConfig } from '@dhis2/app-runtime'
 import i18n from '@dhis2/d2-i18n'
 import { ReactFinalForm } from '@dhis2/ui'
@@ -36,8 +36,9 @@ const initialValues = {
 }
 
 const MetadataDependencyExport = () => {
+    const [exportEnabled, setExportEnabled] = useState(true)
     const { baseUrl } = useConfig()
-    const onSubmit = onExport(baseUrl)
+    const onSubmit = onExport(baseUrl, setExportEnabled)
 
     return (
         <Page
@@ -58,6 +59,7 @@ const MetadataDependencyExport = () => {
                         <SkipSharing />
                         <ExportButton
                             label={i18n.t('Export metadata dependencies')}
+                            disabled={!exportEnabled}
                         />
                     </form>
                 )}

--- a/src/pages/MetadataDependencyExport/form-helper.js
+++ b/src/pages/MetadataDependencyExport/form-helper.js
@@ -1,6 +1,8 @@
 import { locationAssign } from '../../utils/helper'
 
-const onExport = baseUrl => values => {
+const onExport = (baseUrl, setExportEnabled) => values => {
+    setExportEnabled(false)
+
     const { objectType, object, format, compression, skipSharing } = values
 
     const apiBaseUrl = `${baseUrl}/api/`
@@ -8,6 +10,8 @@ const onExport = baseUrl => values => {
     const endpointExtension = compression ? `${format}.${compression}` : format
     const downloadUrlParams = `skipSharing=${skipSharing}&download=true`
     const url = `${apiBaseUrl}${endpoint}.${endpointExtension}?${downloadUrlParams}`
+
+    setTimeout(() => setExportEnabled(true), 5000)
     locationAssign(url)
 }
 

--- a/src/pages/MetadataExport/MetadataExport.js
+++ b/src/pages/MetadataExport/MetadataExport.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { useConfig } from '@dhis2/app-runtime'
 import i18n from '@dhis2/d2-i18n'
 import { ReactFinalForm } from '@dhis2/ui'
@@ -33,8 +33,9 @@ const initialValues = {
 }
 
 const MetadataExport = () => {
+    const [exportEnabled, setExportEnabled] = useState(true)
     const { baseUrl } = useConfig()
-    const onSubmit = onExport(baseUrl)
+    const onSubmit = onExport(baseUrl, setExportEnabled)
 
     return (
         <Page
@@ -52,7 +53,10 @@ const MetadataExport = () => {
                         <Format availableFormats={formatOptions} />
                         <Compression />
                         <SkipSharing />
-                        <ExportButton label={i18n.t('Export metadata')} />
+                        <ExportButton
+                            label={i18n.t('Export metadata')}
+                            disabled={!exportEnabled}
+                        />
                     </form>
                 )}
             />

--- a/src/pages/MetadataExport/form-helper.js
+++ b/src/pages/MetadataExport/form-helper.js
@@ -1,6 +1,8 @@
 import { locationAssign } from '../../utils/helper'
 
-const onExport = baseUrl => values => {
+const onExport = (baseUrl, setExportEnabled) => values => {
+    setExportEnabled(false)
+
     const { checkedSchemas, format, compression, skipSharing } = values
 
     // generate download url
@@ -10,7 +12,9 @@ const onExport = baseUrl => values => {
     const schemaParams = checkedSchemas.map(name => `${name}=true`).join('&')
     const downloadUrlParams = `skipSharing=${skipSharing}&download=true&${schemaParams}`
     const url = `${apiBaseUrl}${endpoint}.${endpointExtension}?${downloadUrlParams}`
+
     locationAssign(url)
+    setTimeout(() => setExportEnabled(true), 5000)
 }
 
 export { onExport }

--- a/src/pages/TEIExport/TEIExport.js
+++ b/src/pages/TEIExport/TEIExport.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { useConfig } from '@dhis2/app-runtime'
 import i18n from '@dhis2/d2-i18n'
 import { ReactFinalForm } from '@dhis2/ui'
@@ -89,8 +89,9 @@ const initialValues = {
 }
 
 const TEIExport = () => {
+    const [exportEnabled, setExportEnabled] = useState(true)
     const { baseUrl } = useConfig()
-    const onSubmit = onExport(baseUrl)
+    const onSubmit = onExport(baseUrl, setExportEnabled)
 
     return (
         <Page
@@ -159,6 +160,7 @@ const TEIExport = () => {
                                 label={i18n.t(
                                     'Export tracked entity instances'
                                 )}
+                                disabled={!exportEnabled}
                             />
                             <FormAlerts alerts={submitError} />
                         </form>

--- a/src/pages/TEIExport/form-helper.js
+++ b/src/pages/TEIExport/form-helper.js
@@ -51,6 +51,7 @@ const valuesToParams = ({
         orgUnitIdScheme: orgUnitIdScheme,
         idScheme: idScheme,
         assignedUserMode: assignedUserMode,
+        download: 'true',
     }
 
     if (compression) {
@@ -112,8 +113,9 @@ const onExport = (baseUrl, setExportEnabled) => async values => {
 
     const apiBaseUrl = `${baseUrl}/api/`
     const endpoint = `trackedEntityInstances`
+    const endpointExtension = compression ? `${format}.${compression}` : format
     const downloadUrlParams = valuesToParams(values)
-    const url = `${apiBaseUrl}${endpoint}?${downloadUrlParams}`
+    const url = `${apiBaseUrl}${endpoint}.${endpointExtension}?${downloadUrlParams}`
 
     // if compression is set we can redirect to the appropriate URL
     // and set the compression parameter

--- a/src/pages/TEIExport/form-helper.js
+++ b/src/pages/TEIExport/form-helper.js
@@ -105,7 +105,9 @@ const valuesToParams = ({
         .join('&')
 }
 
-const onExport = baseUrl => async values => {
+const onExport = (baseUrl, setExportEnabled) => async values => {
+    setExportEnabled(false)
+
     const { format, compression } = values
 
     const apiBaseUrl = `${baseUrl}/api/`
@@ -116,6 +118,7 @@ const onExport = baseUrl => async values => {
     // if compression is set we can redirect to the appropriate URL
     // and set the compression parameter
     if (compression) {
+        setTimeout(() => setExportEnabled(true), 5000)
         locationAssign(url)
         return
     }
@@ -124,6 +127,7 @@ const onExport = baseUrl => async values => {
     try {
         const teis = await fetch(url, {
             Accept: getMimeType(format),
+            credentials: 'include',
         })
         const teiStr = await teis.text()
         const filename = `trackedEntityInstances.${format}`
@@ -142,6 +146,8 @@ const onExport = baseUrl => async values => {
         console.error('TEIExport onExport error: ', error)
 
         return { [FORM_ERROR]: errors }
+    } finally {
+        setExportEnabled(true)
     }
 }
 


### PR DESCRIPTION
When compression is selected we disable the export button for 5 seconds
reason: no way of knowing how long it actually takes the server to respond

Otherwise disable export button until server has responded.

Addresses:
- DHIS2-9488 (Export: missing user feedback when processing)