### PR TITLE
fix(export): show circular loader until download prompt appears

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-09-11T17:40:48.035Z\n"
-"PO-Revision-Date: 2020-09-11T17:40:48.035Z\n"
+"POT-Creation-Date: 2020-09-17T12:32:26.012Z\n"
+"PO-Revision-Date: 2020-09-17T12:32:26.012Z\n"
 
 msgid "Something went wrong when loading the current user!"
 msgstr ""
@@ -830,6 +830,9 @@ msgid "Job started."
 msgstr ""
 
 msgid "An unknown error occurred. Please try again later"
+msgstr ""
+
+msgid "Loading exported data"
 msgstr ""
 
 msgid "Data"

--- a/src/pages/DataExport/DataExport.js
+++ b/src/pages/DataExport/DataExport.js
@@ -72,6 +72,7 @@ const DataExport = () => {
             title={PAGE_NAME}
             desc={PAGE_DESCRIPTION}
             icon={PAGE_ICON}
+            loading={!exportEnabled}
             dataTest="page-export-data"
         >
             <Form

--- a/src/pages/DataExport/form-helper.js
+++ b/src/pages/DataExport/form-helper.js
@@ -55,8 +55,7 @@ const onExport = (baseUrl, setExportEnabled) => async values => {
     // if compression is set we can redirect to the appropriate URL
     // and set the compression parameter
     if (compression) {
-        setTimeout(() => setExportEnabled(true), 5000)
-        locationAssign(url)
+        locationAssign(url, setExportEnabled)
         return
     }
 

--- a/src/pages/EventExport/EventExport.js
+++ b/src/pages/EventExport/EventExport.js
@@ -74,6 +74,7 @@ const EventExport = () => {
             title={PAGE_NAME}
             desc={PAGE_DESCRIPTION}
             icon={PAGE_ICON}
+            loading={!exportEnabled}
             dataTest="page-export-data"
         >
             <Form

--- a/src/pages/EventExport/form-helper.js
+++ b/src/pages/EventExport/form-helper.js
@@ -47,9 +47,7 @@ const onExport = (baseUrl, setExportEnabled) => values => {
         .filter(s => s != '')
         .join('&')
     const url = `${apiBaseUrl}${endpoint}.${endpointExtension}?${downloadUrlParams}`
-
-    setTimeout(() => setExportEnabled(true), 5000)
-    locationAssign(url)
+    locationAssign(url, setExportEnabled)
 }
 
 const validate = values => ({

--- a/src/pages/MetadataDependencyExport/MetadataDependencyExport.js
+++ b/src/pages/MetadataDependencyExport/MetadataDependencyExport.js
@@ -45,6 +45,7 @@ const MetadataDependencyExport = () => {
             title={PAGE_NAME}
             desc={PAGE_DESCRIPTION}
             icon={PAGE_ICON}
+            loading={!exportEnabled}
             dataTest="page-export-metadata-dependency"
         >
             <Form

--- a/src/pages/MetadataDependencyExport/form-helper.js
+++ b/src/pages/MetadataDependencyExport/form-helper.js
@@ -5,14 +5,13 @@ const onExport = (baseUrl, setExportEnabled) => values => {
 
     const { objectType, object, format, compression, skipSharing } = values
 
+    // generate URL and redirect
     const apiBaseUrl = `${baseUrl}/api/`
     const endpoint = `${objectType}/${object}/metadata`
     const endpointExtension = compression ? `${format}.${compression}` : format
     const downloadUrlParams = `skipSharing=${skipSharing}&download=true`
     const url = `${apiBaseUrl}${endpoint}.${endpointExtension}?${downloadUrlParams}`
-
-    setTimeout(() => setExportEnabled(true), 5000)
-    locationAssign(url)
+    locationAssign(url, setExportEnabled)
 }
 
 export { onExport }

--- a/src/pages/MetadataExport/MetadataExport.js
+++ b/src/pages/MetadataExport/MetadataExport.js
@@ -42,6 +42,7 @@ const MetadataExport = () => {
             title={PAGE_NAME}
             desc={PAGE_DESCRIPTION}
             icon={PAGE_ICON}
+            loading={!exportEnabled}
             dataTest="page-export-metadata"
         >
             <Form

--- a/src/pages/MetadataExport/form-helper.js
+++ b/src/pages/MetadataExport/form-helper.js
@@ -12,9 +12,7 @@ const onExport = (baseUrl, setExportEnabled) => values => {
     const schemaParams = checkedSchemas.map(name => `${name}=true`).join('&')
     const downloadUrlParams = `skipSharing=${skipSharing}&download=true&${schemaParams}`
     const url = `${apiBaseUrl}${endpoint}.${endpointExtension}?${downloadUrlParams}`
-
-    locationAssign(url)
-    setTimeout(() => setExportEnabled(true), 5000)
+    locationAssign(url, setExportEnabled)
 }
 
 export { onExport }

--- a/src/pages/TEIExport/TEIExport.js
+++ b/src/pages/TEIExport/TEIExport.js
@@ -98,6 +98,7 @@ const TEIExport = () => {
             title={PAGE_NAME}
             desc={PAGE_DESCRIPTION}
             icon={PAGE_ICON}
+            loading={!exportEnabled}
             dataTest="page-export-tei"
         >
             <Form

--- a/src/pages/TEIExport/form-helper.js
+++ b/src/pages/TEIExport/form-helper.js
@@ -120,8 +120,7 @@ const onExport = (baseUrl, setExportEnabled) => async values => {
     // if compression is set we can redirect to the appropriate URL
     // and set the compression parameter
     if (compression) {
-        setTimeout(() => setExportEnabled(true), 5000)
-        locationAssign(url)
+        locationAssign(url, setExportEnabled)
         return
     }
 

--- a/src/utils/helper.js
+++ b/src/utils/helper.js
@@ -210,12 +210,27 @@ const uploadFile = ({
     })
 }
 
+const downloadWindowTitle = i18n.t('Loading exported data')
+const downloadWindowHtml = `
+<div style="height: 100%; width: 100%; display: flex; justify-content: center; align-items: center; color: rgb(33, 41, 52)">
+    <p>${downloadWindowTitle}</p>
+</div>
+`
+
 // call stub function if available
-const locationAssign = url => {
+const locationAssign = (url, setExportEnabled) => {
     if (window.locationAssign) {
         window.locationAssign(url)
     } else {
-        window.location = url
+        const downloadWindow = window.open(url, '_blank')
+
+        downloadWindow.document.title = downloadWindowTitle
+        downloadWindow.document.body.innerHTML = downloadWindowHtml // does not work in Chrome
+
+        const enableExport = () => setExportEnabled(true)
+        downloadWindow.onbeforeunload = enableExport
+        downloadWindow.onabort = enableExport
+        downloadWindow.onerror = enableExport
     }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2030,17 +2030,17 @@
   dependencies:
     prop-types "^15"
 
-"@dhis2/ui-constants@5.5.5":
-  version "5.5.5"
-  resolved "https://registry.yarnpkg.com/@dhis2/ui-constants/-/ui-constants-5.5.5.tgz#bf88eefdb1b25682aa96be2069d32ba71e6ee55a"
-  integrity sha512-suiiWMvo/tgL8G2EiU8/cpPJjU/lvSPlH5Ls6bbZ7GlGTHOXDH53XbrftY2OuRdqajnaqaibTVDB4VwKH5wGgQ==
+"@dhis2/ui-constants@5.5.6":
+  version "5.5.6"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui-constants/-/ui-constants-5.5.6.tgz#29204a4977216b6973eeff053b8a991ca3752e36"
+  integrity sha512-9qlyLYLan5bk2FtRwHGPATPLdT0EPDFFSYnFdlz98cJvBoL5MTKM70woOEvO0EKcKHdv7Umm2nfCZ5TAri2OBw==
   dependencies:
     "@dhis2/prop-types" "^1.6.4"
 
-"@dhis2/ui-core@5.5.5":
-  version "5.5.5"
-  resolved "https://registry.yarnpkg.com/@dhis2/ui-core/-/ui-core-5.5.5.tgz#559849a3e49c6cf8ee66dc97ed93add42e18f343"
-  integrity sha512-lCioJL4PkIuQcD/6Ka//Z4SYsZsCwI/Y+RhJqBih2RJ4OeKxLKHgCjzX5QoYkjYLrKLRV4ViTopgUkKGH988Vg==
+"@dhis2/ui-core@5.5.6":
+  version "5.5.6"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui-core/-/ui-core-5.5.6.tgz#37e13e300cfd940ec1abe6eb6c30483c58b08215"
+  integrity sha512-flL30mQTFDcbm2xawmcgZ5dME48m9CJz2i4osNTDkhjQuIXwglkD4hAgwgA7Al79QcDycOPlL+MXQtlJuUFNiQ==
   dependencies:
     "@dhis2/prop-types" "^1.6.4"
     "@popperjs/core" "^2.4.4"
@@ -2059,27 +2059,27 @@
     react-popper "^2.2.3"
     resize-observer-polyfill "^1.5.1"
 
-"@dhis2/ui-forms@5.5.5":
-  version "5.5.5"
-  resolved "https://registry.yarnpkg.com/@dhis2/ui-forms/-/ui-forms-5.5.5.tgz#b61a8a354f656a2f8f778f5f73ec9de05ffdb46e"
-  integrity sha512-5DyBXs38kPfSOoNTH+DfmfqX/Zce02T8NGgzWhGvTbIgoJvF5CoryHTC3mJA207f2C0LYe8e20oohVIdrfgUWA==
+"@dhis2/ui-forms@5.5.6":
+  version "5.5.6"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui-forms/-/ui-forms-5.5.6.tgz#e333bc874cb36599dc20d817a7972ad30369b8ea"
+  integrity sha512-gvrFkvA4Z3OPX/SY7Fd0oM17k9fhffQUzDW0+Q38xg/aPSv2BaybAMRwzcS+0abTc8ymXj4wWRxH63W9OQFP+w==
   dependencies:
     "@dhis2/prop-types" "^1.6.4"
     classnames "^2.2.6"
     final-form "^4.20.1"
     react-final-form "^6.5.1"
 
-"@dhis2/ui-icons@5.5.5":
-  version "5.5.5"
-  resolved "https://registry.yarnpkg.com/@dhis2/ui-icons/-/ui-icons-5.5.5.tgz#f243fe847eb02a3fb5b8459460a6b6ec2fedda7c"
-  integrity sha512-9UK1OZFBndVhI3rWS9zJjDAkcDUTVDRENQkdaVgADhBtF/QCsZE6el/hz9zvJuId5ilmpjlpidxYufTgjJ/aBw==
+"@dhis2/ui-icons@5.5.6":
+  version "5.5.6"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui-icons/-/ui-icons-5.5.6.tgz#ae833d78250366b16cac77d13a27bbfe38c465e0"
+  integrity sha512-HAYuuoOHlIzUCErCAtIxjro8PuMu/h+zWek4rLLoqLK2+gNncGa09ZCCONVJv4tfx6mgAHX4CfGtBS07df65Fw==
   dependencies:
     "@dhis2/prop-types" "^1.6.4"
 
-"@dhis2/ui-widgets@5.5.5":
-  version "5.5.5"
-  resolved "https://registry.yarnpkg.com/@dhis2/ui-widgets/-/ui-widgets-5.5.5.tgz#f53ab8be80d2f0a6472f592b019a8eee6042179e"
-  integrity sha512-QKk1UOQeZdEeN5VJyWLS32CNhDxYNavfgNDvgFTMvn5hELeUOEz1hO/DjqzKaJr6WOFjJqWDBzXRsqGaPJS9Bg==
+"@dhis2/ui-widgets@5.5.6":
+  version "5.5.6"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui-widgets/-/ui-widgets-5.5.6.tgz#3ee58f83099d55c1f0821d6620cfd4b2aaef9ebe"
+  integrity sha512-LG1Br/IsBp0O3s0OarnhJbAfs6IzgLLR0scb4kpA9i43tYgj8kJCaxfc7gM44wdKUGuwSpwMz6iKErOx8MTpRg==
   dependencies:
     "@dhis2/prop-types" "^1.6.4"
     classnames "^2.2.6"
@@ -2093,15 +2093,15 @@
     classnames "^2.2.6"
 
 "@dhis2/ui@^5.5.3":
-  version "5.5.5"
-  resolved "https://registry.yarnpkg.com/@dhis2/ui/-/ui-5.5.5.tgz#d982ad369f7249fd9b59280d0ad87fe9dd7d94c5"
-  integrity sha512-G5JMtqQqbBUoiD9dieoI84hPUqgT4qKowbqVc8hQtxEN/SaB+0I9yoWCTZvg2GhR4r+vAuPsZz0AKJdCiM075A==
+  version "5.5.6"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui/-/ui-5.5.6.tgz#c717e01473eda0564ce12db564a50b5c6cd0a47f"
+  integrity sha512-p8mW1aLdZa15kPW2+SWtVN00LUCzRfBGFKUPIaV3XqTlTnRVKuaWf24rmiP6OiUwocXbrpjXFvep9oTLz1JPqQ==
   dependencies:
-    "@dhis2/ui-constants" "5.5.5"
-    "@dhis2/ui-core" "5.5.5"
-    "@dhis2/ui-forms" "5.5.5"
-    "@dhis2/ui-icons" "5.5.5"
-    "@dhis2/ui-widgets" "5.5.5"
+    "@dhis2/ui-constants" "5.5.6"
+    "@dhis2/ui-core" "5.5.6"
+    "@dhis2/ui-forms" "5.5.6"
+    "@dhis2/ui-icons" "5.5.6"
+    "@dhis2/ui-widgets" "5.5.6"
 
 "@hapi/address@2.x.x":
   version "2.1.4"
@@ -7931,11 +7931,6 @@ ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-immediate@~3.0.5:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
-  integrity sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=
-
 immer@1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/immer/-/immer-1.10.0.tgz#bad67605ba9c810275d91e1c2a47d4582e98286d"
@@ -9285,16 +9280,6 @@ jsx-ast-utils@^2.2.1, jsx-ast-utils@^2.2.3:
     array-includes "^3.1.1"
     object.assign "^4.1.0"
 
-jszip@^3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/jszip/-/jszip-3.4.0.tgz#1a69421fa5f0bb9bc222a46bca88182fba075350"
-  integrity sha512-gZAOYuPl4EhPTXT0GjhI3o+ZAz3su6EhLrKUoAivcKqyqC7laS5JEv4XWZND9BgcDcF83vI85yGbDmDR6UhrIg==
-  dependencies:
-    lie "~3.3.0"
-    pako "~1.0.2"
-    readable-stream "~2.3.6"
-    set-immediate-shim "~1.0.1"
-
 keyv@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-3.1.0.tgz#ecc228486f69991e49e9476485a5be1e8fc5c4d9"
@@ -9426,13 +9411,6 @@ levn@^0.3.0, levn@~0.3.0:
   dependencies:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
-
-lie@~3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/lie/-/lie-3.3.0.tgz#dcf82dee545f46074daf200c7c1c5a08e0f40f6a"
-  integrity sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==
-  dependencies:
-    immediate "~3.0.5"
 
 lines-and-columns@^1.1.6:
   version "1.1.6"
@@ -10783,7 +10761,7 @@ pad-right@^0.2.2:
   dependencies:
     repeat-string "^1.5.2"
 
-pako@~1.0.2, pako@~1.0.5:
+pako@~1.0.5:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
   integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
@@ -13249,11 +13227,6 @@ set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
-
-set-immediate-shim@~1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz#4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61"
-  integrity sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=
 
 set-value@^2.0.0, set-value@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
Disabling the export button for an arbitrary 5s regardless of how long it takes the server to respond doesn't really address the initial issue.

`locationAssign` now creates an iframe and leaves the export button disabled until the iframe has loaded which in our case also triggers a browser download prompt to appear.

The whole page also shows a circular loader while we're waiting for the server to respond.

Addresses:
- DHIS2-9488 (Export: missing user feedback when processing)