### PR TITLE
fix(data/tei-export): send attachment parameter

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-09-17T12:32:26.012Z\n"
-"PO-Revision-Date: 2020-09-17T12:32:26.012Z\n"
+"POT-Creation-Date: 2020-09-18T13:18:23.717Z\n"
+"PO-Revision-Date: 2020-09-18T13:18:23.717Z\n"
 
 msgid "Something went wrong when loading the current user!"
 msgstr ""
@@ -741,9 +741,6 @@ msgstr ""
 msgid "Export data"
 msgstr ""
 
-msgid "HTTP error when fetching data"
-msgstr ""
-
 msgid "Import data values from ADX XML, DXF 2 XML, JSON, CSV or PDF files."
 msgstr ""
 
@@ -799,7 +796,7 @@ msgstr ""
 msgid "Tracked entity instances export"
 msgstr ""
 
-msgid "Export tracked entity instances in XML, JSON, JSONP or CSV format."
+msgid "Export tracked entity instances in XML, JSON or CSV format."
 msgstr ""
 
 msgid "Program to export from"
@@ -809,9 +806,6 @@ msgid "Enrollment date range"
 msgstr ""
 
 msgid "Export tracked entity instances"
-msgstr ""
-
-msgid "HTTP error when fetching tracked entity instances"
 msgstr ""
 
 msgid "At least one of the 'last updated' date fields must be specified"

--- a/src/pages/TEIExport/TEIExport.js
+++ b/src/pages/TEIExport/TEIExport.js
@@ -5,7 +5,7 @@ import { ReactFinalForm } from '@dhis2/ui'
 
 import {
     Format,
-    formatJsonpOptions,
+    formatOptions,
     defaultFormatOption,
     OrgUnitTree,
     OrgUnitMode,
@@ -21,8 +21,6 @@ import {
     ProgramEndDate,
     ProgramPicker,
     TETypePicker,
-    Compression,
-    defaultCompressionOption,
     LastUpdatedFilter,
     defaultLastUpdatedFilterOption,
     LastUpdatedStartDate,
@@ -58,7 +56,7 @@ const { Form } = ReactFinalForm
 // PAGE INFO
 const PAGE_NAME = i18n.t('Tracked entity instances export')
 const PAGE_DESCRIPTION = i18n.t(
-    'Export tracked entity instances in XML, JSON, JSONP or CSV format.'
+    'Export tracked entity instances in XML, JSON or CSV format.'
 )
 const PAGE_ICON = <TEIIcon />
 
@@ -74,7 +72,7 @@ const initialValues = {
     followUpStatus: defaultFollowUpStatusOption,
     programStartDate: '',
     programEndDate: '',
-    compression: defaultCompressionOption,
+    compression: '', // disable compression until it is properly implemented in the backend
     lastUpdatedFilter: defaultLastUpdatedFilterOption,
     lastUpdatedStartDate: '',
     lastUpdatedEndDate: '',
@@ -136,8 +134,7 @@ const TEIExport = () => {
                                     <ProgramEndDate show={showProgramFilters} />
                                 </Dates>
                                 <TETypePicker show={showTEFilters} />
-                                <Format availableFormats={formatJsonpOptions} />
-                                <Compression />
+                                <Format availableFormats={formatOptions} />
                             </BasicOptions>
                             <MoreOptions>
                                 <LastUpdatedFilter />

--- a/src/pages/TEIExport/form-helper.js
+++ b/src/pages/TEIExport/form-helper.js
@@ -1,45 +1,40 @@
-import { locationAssign, compressionToName } from '../../utils/helper'
-import { getMimeType } from '../../utils/mime'
+import { locationAssign } from '../../utils/helper'
 import i18n from '@dhis2/d2-i18n'
 
-import { FORM_ERROR } from '../../utils/final-form'
-import {
-    createBlob,
-    downloadBlob,
-    jsDateToISO8601,
-    pathToId,
-} from '../../utils/helper'
+import { jsDateToISO8601, pathToId } from '../../utils/helper'
 import {
     DATE_BEFORE_VALIDATOR,
     DATE_AFTER_VALIDATOR,
 } from '../../components/DatePicker/DatePickerField'
 
 // calculate minimum set of parameters based on given filters
-const valuesToParams = ({
-    selectedOrgUnits,
-    selectedUsers,
-    selectedPrograms,
-    selectedTETypes,
-    ouMode,
-    format,
-    compression,
-    includeDeleted,
-    includeAllAttributes,
-    dataElementIdScheme,
-    eventIdScheme,
-    orgUnitIdScheme,
-    idScheme,
-    assignedUserMode,
-    teiTypeFilter,
-    programStatus,
-    followUpStatus,
-    programStartDate,
-    programEndDate,
-    lastUpdatedFilter,
-    lastUpdatedStartDate,
-    lastUpdatedEndDate,
-    lastUpdatedDuration,
-}) => {
+const valuesToParams = (
+    {
+        selectedOrgUnits,
+        selectedUsers,
+        selectedPrograms,
+        selectedTETypes,
+        ouMode,
+        format,
+        includeDeleted,
+        includeAllAttributes,
+        dataElementIdScheme,
+        eventIdScheme,
+        orgUnitIdScheme,
+        idScheme,
+        assignedUserMode,
+        teiTypeFilter,
+        programStatus,
+        followUpStatus,
+        programStartDate,
+        programEndDate,
+        lastUpdatedFilter,
+        lastUpdatedStartDate,
+        lastUpdatedEndDate,
+        lastUpdatedDuration,
+    },
+    filename
+) => {
     const minParams = {
         ou: selectedOrgUnits.map(o => pathToId(o)).join(';'),
         ouMode: ouMode,
@@ -51,11 +46,7 @@ const valuesToParams = ({
         orgUnitIdScheme: orgUnitIdScheme,
         idScheme: idScheme,
         assignedUserMode: assignedUserMode,
-        download: 'true',
-    }
-
-    if (compression) {
-        minParams.compression = compressionToName(compression)
+        attachment: filename,
     }
 
     if (assignedUserMode == 'PROVIDED') {
@@ -109,47 +100,15 @@ const valuesToParams = ({
 const onExport = (baseUrl, setExportEnabled) => async values => {
     setExportEnabled(false)
 
-    const { format, compression } = values
+    const { format } = values
 
+    // generate URL and redirect
     const apiBaseUrl = `${baseUrl}/api/`
     const endpoint = `trackedEntityInstances`
-    const endpointExtension = compression ? `${format}.${compression}` : format
-    const downloadUrlParams = valuesToParams(values)
-    const url = `${apiBaseUrl}${endpoint}.${endpointExtension}?${downloadUrlParams}`
-
-    // if compression is set we can redirect to the appropriate URL
-    // and set the compression parameter
-    if (compression) {
-        locationAssign(url, setExportEnabled)
-        return
-    }
-
-    // fetch data and create blob
-    try {
-        const teis = await fetch(url, {
-            Accept: getMimeType(format),
-            credentials: 'include',
-        })
-        const teiStr = await teis.text()
-        const filename = `trackedEntityInstances.${format}`
-        const downloadUrl = createBlob(teiStr, format)
-        downloadBlob(downloadUrl, filename)
-    } catch (error) {
-        const errors = [
-            {
-                id: `http-${new Date().getTime()}`,
-                critical: true,
-                message: `${i18n.t(
-                    'HTTP error when fetching tracked entity instances'
-                )}. ${error.message}`,
-            },
-        ]
-        console.error('TEIExport onExport error: ', error)
-
-        return { [FORM_ERROR]: errors }
-    } finally {
-        setExportEnabled(true)
-    }
+    const filename = `${endpoint}.${format}`
+    const downloadUrlParams = valuesToParams(values, filename)
+    const url = `${apiBaseUrl}${endpoint}.${format}?${downloadUrlParams}`
+    locationAssign(url, setExportEnabled)
 }
 
 const validate = values => {

--- a/src/utils/helper.js
+++ b/src/utils/helper.js
@@ -1,6 +1,5 @@
 import i18n from '@dhis2/d2-i18n'
 
-import { getMimeType } from './mime'
 import { getUploadXHR } from './xhr'
 
 const trimString = (length, string) =>
@@ -38,30 +37,6 @@ const compressionToName = compression => {
         return 'gzip'
     }
     return compression
-}
-
-const blobType = (format, compression) => {
-    if (compression === 'gzip') {
-        return `application/${format}+gzip`
-    } else if (compression === 'zip') {
-        return `application/${format}+zip`
-    }
-    return getMimeType(format)
-}
-
-const createBlob = (contents, format, compression = 'none') => {
-    return URL.createObjectURL(
-        new Blob([contents], { type: blobType(format, compression) })
-    )
-}
-
-const downloadBlob = (url, filename) => {
-    const link = document.createElement('a')
-    link.href = url
-    link.setAttribute('download', filename)
-    document.body.appendChild(link)
-    link.click()
-    link.remove()
 }
 
 const fetchAttributes = async (apiBaseUrl, attribute) => {
@@ -251,8 +226,6 @@ const getInitialBoolValue = (prevValue, defaultValue) => {
 }
 
 export {
-    createBlob,
-    downloadBlob,
     fetchAttributes,
     getPrevJobDetails,
     getInitialBoolValue,


### PR DESCRIPTION
The `dataValueSets` and `trackedEntityInstances` endpoints added support for the `attachment` parameter.
Client-side blob creation is now completely gone.

Addresses:
- DHIS2-9445 (Exported TEIs open in the browser, file is not downloaded)

See:
- DHIS2-9496 (Add download flag to dataValueSets and trackedEntityInstances)
  - https://github.com/dhis2/dhis2-core/pull/6184
