### PR TITLE
fix(tei-export/org-unit-mode): correctly show ouMode overrides

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-09-18T13:18:23.717Z\n"
-"PO-Revision-Date: 2020-09-18T13:18:23.717Z\n"
+"POT-Creation-Date: 2020-09-21T10:23:12.685Z\n"
+"PO-Revision-Date: 2020-09-21T10:23:12.685Z\n"
 
 msgid "Something went wrong when loading the current user!"
 msgstr ""
@@ -421,6 +421,12 @@ msgid "Capture"
 msgstr ""
 
 msgid "All organisation units in the system"
+msgstr ""
+
+msgid "Manually select organisation units from list"
+msgstr ""
+
+msgid "Which organisation units should be included?"
 msgstr ""
 
 msgid "Organisation unit(s) to export data from"

--- a/src/components/Inputs/OrgUnitMode.js
+++ b/src/components/Inputs/OrgUnitMode.js
@@ -1,25 +1,13 @@
 import React, { useContext } from 'react'
+import PropTypes from 'prop-types'
 import i18n from '@dhis2/d2-i18n'
 import { UserContext } from '../../contexts/index'
 import { hasAuthorityToSelectAllOrgUnits } from '../WithAuthority/predicates'
 import { RadioGroupField } from '../index'
+import { OrgUnitTree, Inclusion } from './index'
 
+const OU_MODE_MANUAL_VALUE = ':MANUAL:'
 const orgUnitSelectionModeOptions = [
-    {
-        value: 'SELECTED',
-        label: i18n.t('Only include selected organisation unit'),
-        prefix: i18n.t('Selected'),
-    },
-    {
-        value: 'CHILDREN',
-        label: i18n.t('Include the first level of units inside selections'),
-        prefix: i18n.t('Directly below'),
-    },
-    {
-        value: 'DESCENDANTS',
-        label: i18n.t('Include all units inside selections'),
-        prefix: i18n.t('All below'),
-    },
     {
         value: 'ACCESSIBLE',
         label: i18n.t(
@@ -39,16 +27,18 @@ const orgUnitSelectionModeOptions = [
         label: i18n.t('All organisation units in the system'),
         prefix: i18n.t('All'),
     },
+    {
+        value: OU_MODE_MANUAL_VALUE,
+        label: i18n.t('Manually select organisation units from list'),
+    },
 ]
-const defaultOrgUnitSelectionModeOption = orgUnitSelectionModeOptions[0].value
+const defaultOrgUnitSelectionModeOption = orgUnitSelectionModeOptions[3].value
 
 const NAME = 'ouMode'
 const DATATEST = 'input-ouMode'
-const LABEL = i18n.t(
-    'How should organisation units inside the selections be included?'
-)
+const LABEL = i18n.t('Which organisation units should be included?')
 
-const OrgUnitMode = () => {
+const OrgUnitMode = ({ value }) => {
     const user = useContext(UserContext)
     const canSelectAllOrgUnits = user
         ? hasAuthorityToSelectAllOrgUnits(user.authorities)
@@ -64,8 +54,19 @@ const OrgUnitMode = () => {
             options={options}
             dataTest={DATATEST}
             vertical
-        />
+        >
+            {value === OU_MODE_MANUAL_VALUE && (
+                <>
+                    <OrgUnitTree />
+                    <Inclusion />
+                </>
+            )}
+        </RadioGroupField>
     )
 }
 
-export { OrgUnitMode, defaultOrgUnitSelectionModeOption }
+OrgUnitMode.propTypes = {
+    value: PropTypes.string.isRequired,
+}
+
+export { OrgUnitMode, defaultOrgUnitSelectionModeOption, OU_MODE_MANUAL_VALUE }

--- a/src/components/Inputs/index.js
+++ b/src/components/Inputs/index.js
@@ -63,7 +63,11 @@ export {
     OrgUnitIdScheme,
     defaultOrgUnitIdSchemeOption,
 } from './OrgUnitIdScheme'
-export { OrgUnitMode, defaultOrgUnitSelectionModeOption } from './OrgUnitMode'
+export {
+    OrgUnitMode,
+    defaultOrgUnitSelectionModeOption,
+    OU_MODE_MANUAL_VALUE,
+} from './OrgUnitMode'
 export { TEITypeFilter, defaultTEITypeFilterOption } from './TEITypeFilter'
 export { ProgramStatus, defaultProgramStatusOption } from './ProgramStatus'
 export { FollowUpStatus, defaultFollowUpStatusOption } from './FollowUpStatus'

--- a/src/pages/TEIExport/TEIExport.js
+++ b/src/pages/TEIExport/TEIExport.js
@@ -7,9 +7,9 @@ import {
     Format,
     formatOptions,
     defaultFormatOption,
-    OrgUnitTree,
     OrgUnitMode,
     defaultOrgUnitSelectionModeOption,
+    defaultInclusionOption,
     TEITypeFilter,
     defaultTEITypeFilterOption,
     ProgramStatus,
@@ -67,6 +67,7 @@ const initialValues = {
     selectedUsers: [],
     format: defaultFormatOption,
     ouMode: defaultOrgUnitSelectionModeOption,
+    inclusion: defaultInclusionOption,
     teiTypeFilter: defaultTEITypeFilterOption,
     programStatus: defaultProgramStatusOption,
     followUpStatus: defaultFollowUpStatusOption,
@@ -115,8 +116,7 @@ const TEIExport = () => {
                     return (
                         <form onSubmit={handleSubmit}>
                             <BasicOptions>
-                                <OrgUnitTree />
-                                <OrgUnitMode />
+                                <OrgUnitMode value={values.ouMode} />
                                 <TEITypeFilter />
                                 <ProgramPicker
                                     label={i18n.t('Program to export from')}

--- a/src/pages/TEIExport/form-helper.js
+++ b/src/pages/TEIExport/form-helper.js
@@ -2,6 +2,7 @@ import { locationAssign } from '../../utils/helper'
 import i18n from '@dhis2/d2-i18n'
 
 import { jsDateToISO8601, pathToId } from '../../utils/helper'
+import { OU_MODE_MANUAL_VALUE } from '../../components/Inputs/index'
 import {
     DATE_BEFORE_VALIDATOR,
     DATE_AFTER_VALIDATOR,
@@ -15,6 +16,7 @@ const valuesToParams = (
         selectedPrograms,
         selectedTETypes,
         ouMode,
+        inclusion,
         format,
         includeDeleted,
         includeAllAttributes,
@@ -36,7 +38,6 @@ const valuesToParams = (
     filename
 ) => {
     const minParams = {
-        ou: selectedOrgUnits.map(o => pathToId(o)).join(';'),
         ouMode: ouMode,
         format: format,
         includeDeleted: includeDeleted.toString(),
@@ -47,6 +48,13 @@ const valuesToParams = (
         idScheme: idScheme,
         assignedUserMode: assignedUserMode,
         attachment: filename,
+    }
+
+    // include selected org.units only when manual selection is selected
+    // ouMode is then stored in the `inclusion` field
+    if (ouMode === OU_MODE_MANUAL_VALUE) {
+        minParams.ou = selectedOrgUnits.map(o => pathToId(o)).join(';')
+        minParams.ouMode = inclusion
     }
 
     if (assignedUserMode == 'PROVIDED') {
@@ -108,6 +116,7 @@ const onExport = (baseUrl, setExportEnabled) => async values => {
     const filename = `${endpoint}.${format}`
     const downloadUrlParams = valuesToParams(values, filename)
     const url = `${apiBaseUrl}${endpoint}.${format}?${downloadUrlParams}`
+
     locationAssign(url, setExportEnabled)
 }
 


### PR DESCRIPTION
Accessible, capture and ALL overrides the manual selection and the UI now reflects these overrides.

Addresses:
- DHIS2-9545 (Unclear if 'accessible' and 'capture' units overrride org.unit selection)

### Preview
![image](https://user-images.githubusercontent.com/16868802/93758623-1676a180-fc09-11ea-97ac-232489c22fb0.png)
