### PR TITLE
fix: tei export assigned user mode

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-09-17T21:11:04.970Z\n"
-"PO-Revision-Date: 2020-09-17T21:11:04.970Z\n"
+"POT-Creation-Date: 2020-09-25T12:32:54.628Z\n"
+"PO-Revision-Date: 2020-09-25T12:32:54.628Z\n"
 
 msgid "Something went wrong when loading the current user!"
 msgstr ""
@@ -65,6 +65,12 @@ msgid "Selected users"
 msgstr ""
 
 msgid "Assigned user mode"
+msgstr ""
+
+msgid "Filter by assigned user mode"
+msgstr ""
+
+msgid "Filter tracked entity instances with events assigned to specific users"
 msgstr ""
 
 msgid "Do not import"

--- a/src/components/Inputs/AssignedUserMode.js
+++ b/src/components/Inputs/AssignedUserMode.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import i18n from '@dhis2/d2-i18n'
 import { RadioGroupField } from '../index'
 
@@ -14,13 +15,18 @@ const NAME = 'assignedUserMode'
 const DATATEST = 'input-assigned-user-mode'
 const LABEL = i18n.t('Assigned user mode')
 
-const AssignedUserMode = () => (
-    <RadioGroupField
-        name={NAME}
-        label={LABEL}
-        options={assignedUserModeOptions}
-        dataTest={DATATEST}
-    />
-)
+const AssignedUserMode = ({ show }) =>
+    show && (
+        <RadioGroupField
+            name={NAME}
+            label={LABEL}
+            options={assignedUserModeOptions}
+            dataTest={DATATEST}
+        />
+    )
+
+AssignedUserMode.propTypes = {
+    show: PropTypes.bool,
+}
 
 export { AssignedUserMode, defaultAssignedUserModeOption }

--- a/src/components/Inputs/AssignedUserModeFilter.js
+++ b/src/components/Inputs/AssignedUserModeFilter.js
@@ -1,0 +1,27 @@
+import React from 'react'
+import i18n from '@dhis2/d2-i18n'
+import { ReactFinalForm, CheckboxFieldFF } from '@dhis2/ui'
+import { FormField } from '../index'
+
+const { Field } = ReactFinalForm
+
+const NAME = 'assignedUserModeFilter'
+const DATATEST = 'input-assigned-user-mode-filter'
+const SHORT_LABEL = i18n.t('Filter by assigned user mode')
+const LABEL = i18n.t(
+    'Filter tracked entity instances with events assigned to specific users'
+)
+
+const AssignedUserModeFilter = () => (
+    <FormField label={SHORT_LABEL} dataTest={DATATEST}>
+        <Field
+            type="checkbox"
+            component={CheckboxFieldFF}
+            name={NAME}
+            label={LABEL}
+            dataTest={`${DATATEST}-sf`}
+        />
+    </FormField>
+)
+
+export { AssignedUserModeFilter }

--- a/src/components/Inputs/index.js
+++ b/src/components/Inputs/index.js
@@ -88,3 +88,4 @@ export {
 export { UserPicker } from './UserPicker'
 export { IncludeAllAttributes } from './IncludeAllAttributes'
 export { Dates } from './Dates'
+export { AssignedUserModeFilter } from './AssignedUserModeFilter'

--- a/src/pages/DataExport/form-helper.js
+++ b/src/pages/DataExport/form-helper.js
@@ -52,6 +52,9 @@ const onExport = (baseUrl, setExportEnabled) => async values => {
     const downloadUrlParams = valuesToParams(values, filename)
     const url = `${apiBaseUrl}${endpoint}?${downloadUrlParams}`
     locationAssign(url, setExportEnabled)
+
+    // log for debugging purposes
+    console.log('data-export:', { url, params: downloadUrlParams })
 }
 
 const validate = values => ({

--- a/src/pages/EventExport/form-helper.js
+++ b/src/pages/EventExport/form-helper.js
@@ -48,6 +48,9 @@ const onExport = (baseUrl, setExportEnabled) => values => {
         .join('&')
     const url = `${apiBaseUrl}${endpoint}.${endpointExtension}?${downloadUrlParams}`
     locationAssign(url, setExportEnabled)
+
+    // log for debugging purposes
+    console.log('event-export:', { url, params: downloadUrlParams })
 }
 
 const validate = values => ({

--- a/src/pages/MetadataDependencyExport/form-helper.js
+++ b/src/pages/MetadataDependencyExport/form-helper.js
@@ -12,6 +12,12 @@ const onExport = (baseUrl, setExportEnabled) => values => {
     const downloadUrlParams = `skipSharing=${skipSharing}&download=true`
     const url = `${apiBaseUrl}${endpoint}.${endpointExtension}?${downloadUrlParams}`
     locationAssign(url, setExportEnabled)
+
+    // log for debugging purposes
+    console.log('metadata-dependency-export:', {
+        url,
+        params: downloadUrlParams,
+    })
 }
 
 export { onExport }

--- a/src/pages/MetadataExport/form-helper.js
+++ b/src/pages/MetadataExport/form-helper.js
@@ -13,6 +13,9 @@ const onExport = (baseUrl, setExportEnabled) => values => {
     const downloadUrlParams = `skipSharing=${skipSharing}&download=true&${schemaParams}`
     const url = `${apiBaseUrl}${endpoint}.${endpointExtension}?${downloadUrlParams}`
     locationAssign(url, setExportEnabled)
+
+    // log for debugging purposes
+    console.log('metadata-export:', { url, params: downloadUrlParams })
 }
 
 export { onExport }

--- a/src/pages/TEIExport/TEIExport.js
+++ b/src/pages/TEIExport/TEIExport.js
@@ -26,6 +26,7 @@ import {
     LastUpdatedStartDate,
     LastUpdatedEndDate,
     LastUpdatedDuration,
+    AssignedUserModeFilter,
     AssignedUserMode,
     defaultAssignedUserModeOption,
     UserPicker,
@@ -79,6 +80,7 @@ const initialValues = {
     lastUpdatedStartDate: '',
     lastUpdatedEndDate: '',
     lastUpdatedDuration: '',
+    assignedUserModeFilter: false,
     assignedUserMode: defaultAssignedUserModeOption,
     includeDeleted: false,
     includeAllAttributes: false,
@@ -115,6 +117,7 @@ const TEIExport = () => {
                     const showLUDates = values.lastUpdatedFilter == 'DATE'
                     const showLUDuration =
                         values.lastUpdatedFilter == 'DURATION'
+                    const showAssignedUserMode = values.assignedUserModeFilter
                     const showUserPicker = values.assignedUserMode == 'PROVIDED'
 
                     return (
@@ -147,7 +150,8 @@ const TEIExport = () => {
                                     <LastUpdatedEndDate show={showLUDates} />
                                 </Dates>
                                 <LastUpdatedDuration show={showLUDuration} />
-                                <AssignedUserMode />
+                                <AssignedUserModeFilter />
+                                <AssignedUserMode show={showAssignedUserMode} />
                                 <UserPicker show={showUserPicker} />
                                 <IncludeDeleted />
                                 <IncludeAllAttributes />

--- a/src/pages/TEIExport/form-helper.js
+++ b/src/pages/TEIExport/form-helper.js
@@ -120,8 +120,10 @@ const onExport = (baseUrl, setExportEnabled) => async values => {
     const filename = `${endpoint}.${format}`
     const downloadUrlParams = valuesToParams(values, filename)
     const url = `${apiBaseUrl}${endpoint}.${format}?${downloadUrlParams}`
-
     locationAssign(url, setExportEnabled)
+
+    // log for debugging purposes
+    console.log('tei-export:', { url, params: downloadUrlParams })
 }
 
 const validate = values => {

--- a/src/pages/TEIExport/form-helper.js
+++ b/src/pages/TEIExport/form-helper.js
@@ -24,6 +24,7 @@ const valuesToParams = (
         eventIdScheme,
         orgUnitIdScheme,
         idScheme,
+        assignedUserModeFilter,
         assignedUserMode,
         teiTypeFilter,
         programStatus,
@@ -46,7 +47,6 @@ const valuesToParams = (
         eventIdScheme: eventIdScheme,
         orgUnitIdScheme: orgUnitIdScheme,
         idScheme: idScheme,
-        assignedUserMode: assignedUserMode,
         attachment: filename,
     }
 
@@ -55,6 +55,10 @@ const valuesToParams = (
     if (ouMode === OU_MODE_MANUAL_VALUE) {
         minParams.ou = selectedOrgUnits.map(o => pathToId(o)).join(';')
         minParams.ouMode = inclusion
+    }
+
+    if (assignedUserModeFilter) {
+        minParams.assignedUserMode = assignedUserMode
     }
 
     if (assignedUserMode == 'PROVIDED') {


### PR DESCRIPTION
Adds a new default option to `Assigned user mode` that disables filtering by `assignedUserMode`.

### Reason
`assignedUserMode` set to `ANY` is not the same excluding the parameter completely from the parameters.

