### PR TITLE
fix(tei-export): only include `assignedUser` parameter if `filter by assigned user` is selected

### DIFF
--- a/src/components/Inputs/AssignedUserMode.js
+++ b/src/components/Inputs/AssignedUserMode.js
@@ -2,6 +2,7 @@ import React from 'react'
 import i18n from '@dhis2/d2-i18n'
 import { ReactFinalForm, CheckboxFieldFF } from '@dhis2/ui'
 import { FormField, RadioGroupField } from '../index'
+import { UserPicker } from './index'
 
 const { useField, Field } = ReactFinalForm
 
@@ -25,8 +26,12 @@ const DATATEST = 'input-assigned-user-mode'
 const LABEL = i18n.t('Assigned user(s)')
 
 const AssignedUserMode = () => {
-    const { input } = useField(FILTER_NAME)
-    const { value: showOptions } = input
+    const { input: filterInput } = useField(FILTER_NAME)
+    const { value: showOptions } = filterInput
+
+    const { input: userInput } = useField(NAME)
+    const { value: userMode } = userInput
+    const showUserPicker = userMode === 'PROVIDED'
 
     return (
         <>
@@ -51,6 +56,7 @@ const AssignedUserMode = () => {
                             dataTest={DATATEST}
                             label={LABEL}
                         />
+                        <UserPicker show={showUserPicker} />
                     </div>
                 )}
             </FormField>

--- a/src/pages/TEIExport/TEIExport.js
+++ b/src/pages/TEIExport/TEIExport.js
@@ -28,7 +28,6 @@ import {
     LastUpdatedDuration,
     AssignedUserMode,
     defaultAssignedUserModeOption,
-    UserPicker,
     IncludeDeleted,
     IncludeAllAttributes,
     DataElementIdScheme,
@@ -116,7 +115,6 @@ const TEIExport = () => {
                     const showLUDates = values.lastUpdatedFilter == 'DATE'
                     const showLUDuration =
                         values.lastUpdatedFilter == 'DURATION'
-                    const showUserPicker = values.assignedUserMode == 'PROVIDED'
 
                     return (
                         <form onSubmit={handleSubmit}>
@@ -149,7 +147,6 @@ const TEIExport = () => {
                                 </Dates>
                                 <LastUpdatedDuration show={showLUDuration} />
                                 <AssignedUserMode />
-                                <UserPicker show={showUserPicker} />
                                 <IncludeDeleted />
                                 <IncludeAllAttributes />
                                 <SchemeContainer>

--- a/src/pages/TEIExport/form-helper.js
+++ b/src/pages/TEIExport/form-helper.js
@@ -59,10 +59,10 @@ const valuesToParams = (
 
     if (assignedUserModeFilter) {
         minParams.assignedUserMode = assignedUserMode
-    }
 
-    if (assignedUserMode == 'PROVIDED') {
-        minParams.assignedUser = selectedUsers.join(';')
+        if (assignedUserMode == 'PROVIDED') {
+            minParams.assignedUser = selectedUsers.join(';')
+        }
     }
 
     if (teiTypeFilter == 'PROGRAM') {


### PR DESCRIPTION
- only include the `assignedUser` parameter if `filter by assigned user` is selected
- aligns user picker with the rest of the related fields