### PR TITLE
fix: job overview wording and job selection

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-09-30T15:40:42.897Z\n"
-"PO-Revision-Date: 2020-09-30T15:40:42.897Z\n"
+"POT-Creation-Date: 2020-10-01T09:54:04.640Z\n"
+"PO-Revision-Date: 2020-10-01T09:54:04.640Z\n"
 
 msgid "Something went wrong when loading the current user!"
 msgstr ""
@@ -592,18 +592,6 @@ msgstr ""
 msgid "Value"
 msgstr ""
 
-msgid "Events"
-msgstr ""
-
-msgid "Time"
-msgstr ""
-
-msgid "Message"
-msgstr ""
-
-msgid "ID"
-msgstr ""
-
 msgid "Job summary"
 msgstr ""
 
@@ -614,6 +602,18 @@ msgid "Conflicts"
 msgstr ""
 
 msgid "Dry run"
+msgstr ""
+
+msgid "Log"
+msgstr ""
+
+msgid "Time"
+msgstr ""
+
+msgid "Message"
+msgstr ""
+
+msgid "ID"
 msgstr ""
 
 msgid "Messages"
@@ -652,10 +652,10 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
-msgid "Overview"
+msgid "Details by type"
 msgstr ""
 
-msgid "Type count"
+msgid "Overview"
 msgstr ""
 
 msgid "Advanced options"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-10-01T09:54:04.640Z\n"
-"PO-Revision-Date: 2020-10-01T09:54:04.640Z\n"
+"POT-Creation-Date: 2020-10-05T08:18:24.656Z\n"
+"PO-Revision-Date: 2020-10-05T08:18:24.656Z\n"
 
 msgid "Something went wrong when loading the current user!"
 msgstr ""
@@ -655,9 +655,6 @@ msgstr ""
 msgid "Details by type"
 msgstr ""
 
-msgid "Overview"
-msgstr ""
-
 msgid "Advanced options"
 msgstr ""
 
@@ -719,6 +716,9 @@ msgid "TEI export"
 msgstr ""
 
 msgid "Job overview"
+msgstr ""
+
+msgid "Overview"
 msgstr ""
 
 msgid "Yes"

--- a/src/components/JobOverview/JobOverview.js
+++ b/src/components/JobOverview/JobOverview.js
@@ -46,12 +46,12 @@ const JobOverview = ({
     // set selected job to first job if
     // first time user visits the job overview page
     useEffect(() => {
-        if (!selectedJob && allTasks.length > 0) {
+        if (selectedJob === undefined && allTasks.length > 0) {
             setSelectedJob(allTasks[0])
         }
     }, [])
 
-    if (!selectedJob) {
+    if (allTasks.length === 0) {
         return <p>{i18n.t('No jobs started yet.')}</p>
     }
 
@@ -74,7 +74,7 @@ const JobOverview = ({
                     {filteredTasks.map(t => (
                         <MenuItem
                             key={`job-overview-tasks-${t.id}`}
-                            active={selectedJob.id == t.id}
+                            active={selectedJob && selectedJob.id === t.id}
                             label={<MenuLabel task={t} />}
                             onClick={() => setSelectedJob(t)}
                             icon={categoryTypesObj[t.importType].icon}
@@ -83,15 +83,19 @@ const JobOverview = ({
                 </Menu>
             </div>
             <div className={styles.summary} data-test="job-overview-summary">
-                <JobSummary
-                    task={selectedJob}
-                    dataTest="job-summary-container"
-                    showFileDetails={false}
-                    showJobDetails={true}
-                />
-                <Link to={jobToPath(selectedJob)}>
-                    <Button primary>{i18n.t('Recreate job')}</Button>
-                </Link>
+                {selectedJob && (
+                    <>
+                        <JobSummary
+                            task={selectedJob}
+                            dataTest="job-summary-container"
+                            showFileDetails={false}
+                            showJobDetails={true}
+                        />
+                        <Link to={jobToPath(selectedJob)}>
+                            <Button primary>{i18n.t('Recreate job')}</Button>
+                        </Link>
+                    </>
+                )}
             </div>
         </div>
     )

--- a/src/components/JobOverview/JobOverview.module.css
+++ b/src/components/JobOverview/JobOverview.module.css
@@ -2,19 +2,39 @@
     display: grid;
     grid-gap: 20px;
     grid-template-rows: auto;
-    grid-template-columns: [items] 330px [summary] minmax(0, 1fr);
+    grid-template-columns: 1fr;
     height: 100%;
 }
 
-.items {
-    grid-column: items;
-    height: 100%;
+.chips {
+    margin-bottom: var(--spacers-dp4);
 }
 
 .Menu {
-    height: 100%;
+    padding-bottom: var(--spacers-dp16) !important;
+    border-bottom: 1px solid var(--colors-grey300);
+    max-height: var(--spacers-dp512);
+    overflow: auto;
 }
 
-.summary {
-    grid-column: summary;
+@media (min-width: 1200px) {
+    .container {
+        grid-template-columns: [items] 350px [summary] minmax(0, 1fr);
+    }
+
+    .items {
+        grid-column: items;
+        height: 100%;
+    }
+
+    .Menu {
+        height: 100%;
+        padding: 0 !important;
+        border-bottom: none;
+        max-height: 100%;
+    }
+
+    .summary {
+        grid-column: summary;
+    }
 }

--- a/src/components/JobOverview/MenuLabel/MenuLabel.js
+++ b/src/components/JobOverview/MenuLabel/MenuLabel.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import i18n from '@dhis2/d2-i18n'
 
 import styles from './MenuLabel.module.css'
-import { jsDateToString, trimString } from '../../../utils/helper'
+import { jsDateToString } from '../../../utils/helper'
 
 const MenuLabel = ({ task }) => {
     return (
@@ -12,7 +12,9 @@ const MenuLabel = ({ task }) => {
             data-test={`job-overview-menu-label-${task.id}`}
         >
             <div className={styles.status}>
-                <span>{trimString(15, task.jobDetails.files[0].name)}</span>
+                <span className={styles.filename}>
+                    {task.jobDetails.files[0].name}
+                </span>
                 <br />
                 <span>
                     {task.completed

--- a/src/components/JobOverview/MenuLabel/MenuLabel.module.css
+++ b/src/components/JobOverview/MenuLabel/MenuLabel.module.css
@@ -1,12 +1,27 @@
 .container {
     display: flex;
     align-items: center;
+    justify-content: space-between;
 }
 
 .status {
-    min-width: 100px;
+    min-width: 120px;
+}
+
+.filename {
+    display: inline-block;
+    width: 300px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .date {
     margin-left: 20px;
+}
+
+@media (min-width: 1200px) {
+    .filename {
+        width: 120px;
+    }
 }

--- a/src/components/JobOverview/__test__/__snapshots__/JobOverview.test.js.snap
+++ b/src/components/JobOverview/__test__/__snapshots__/JobOverview.test.js.snap
@@ -9,7 +9,9 @@ exports[`MenuLabel matches snapshot 1`] = `
     <div
       class="status"
     >
-      <span>
+      <span
+        class="filename"
+      >
         data1.json
       </span>
       <br />

--- a/src/components/JobOverview/__test__/__snapshots__/MenuLabel.test.js.snap
+++ b/src/components/JobOverview/__test__/__snapshots__/MenuLabel.test.js.snap
@@ -9,7 +9,9 @@ exports[`matches snapshot 1`] = `
     <div
       class="status"
     >
-      <span>
+      <span
+        class="filename"
+      >
         data1.json
       </span>
       <br />

--- a/src/components/JobSummary/JobSummary.js
+++ b/src/components/JobSummary/JobSummary.js
@@ -5,7 +5,7 @@ import { Divider, Tag } from '@dhis2/ui'
 
 import styles from './JobSummary.module.css'
 import { jsDateToString } from '../../utils/helper'
-import { Events } from './Events/Events'
+import { Log } from './Log/Log'
 import { Summary } from './Summary/Summary'
 import { Details } from './Details/Details'
 
@@ -84,7 +84,7 @@ const JobSummary = ({
                 <Summary summary={task.summary} />
             )}
             <div className={styles.events}>
-                <Events events={task.events} />
+                <Log events={task.events} />
             </div>
             {showJobDetails && (
                 <div className={styles.jobDetails}>

--- a/src/components/JobSummary/Log/Log.js
+++ b/src/components/JobSummary/Log/Log.js
@@ -14,12 +14,12 @@ import {
 import { jsDateToString } from '../../../utils/helper'
 import { FormField } from '../../index'
 
-const Events = ({ events }) => {
+const Log = ({ events }) => {
     return (
         <FormField
-            label={`${i18n.t('Events')}`}
-            dataTest="job-summary-events"
-            name="events"
+            label={`${i18n.t('Log')}`}
+            dataTest="job-summary-log"
+            name="log"
         >
             <Table>
                 <TableHead>
@@ -32,7 +32,7 @@ const Events = ({ events }) => {
                 <TableBody>
                     {(events || null) &&
                         events.map((e, i) => (
-                            <TableRow key={`job-summary-events-${e.id}-${i}`}>
+                            <TableRow key={`job-summary-log-${e.id}-${i}`}>
                                 <TableCell>{jsDateToString(e.date)}</TableCell>
                                 <TableCell>{e.text}</TableCell>
                                 <TableCell>{e.id}</TableCell>
@@ -50,8 +50,8 @@ const eventPropType = PropTypes.shape({
     text: PropTypes.string.isRequired,
 })
 
-Events.propTypes = {
+Log.propTypes = {
     events: PropTypes.arrayOf(eventPropType),
 }
 
-export { Events }
+export { Log }

--- a/src/components/JobSummary/SingleSummary/SingleSummary.js
+++ b/src/components/JobSummary/SingleSummary/SingleSummary.js
@@ -18,7 +18,7 @@ import { FormField } from '../../index'
 const SingleSummary = ({ importCount, status, description, conflicts, id }) => (
     <div>
         <FormField
-            label={`${i18n.t('Summary')} #${id}`}
+            label={id ? `${i18n.t('Summary')} #${id}` : i18n.t('Summary')}
             dataTest="job-summary-single-summary"
             name="summary"
         >
@@ -81,7 +81,6 @@ const SingleSummary = ({ importCount, status, description, conflicts, id }) => (
 )
 
 SingleSummary.propTypes = {
-    id: PropTypes.string.isRequired,
     importCount: statsPropType.isRequired,
     conflicts: PropTypes.arrayOf(
         PropTypes.exact({
@@ -90,6 +89,7 @@ SingleSummary.propTypes = {
         })
     ),
     description: PropTypes.string,
+    id: PropTypes.string,
     status: PropTypes.string,
 }
 

--- a/src/components/JobSummary/Summary/Summary.js
+++ b/src/components/JobSummary/Summary/Summary.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import i18n from '@dhis2/d2-i18n'
 
 import styles from './Summary.module.css'
 import { typeReportParse } from '../helper'
@@ -55,7 +54,6 @@ const Summary = ({ summary }) => {
                 (summary.conflicts.length || null) &&
                 summary.conflicts
             }
-            id={i18n.t('Overview')}
         />
     )
     const allSummaries =

--- a/src/components/JobSummary/TypeCount/TypeCount.js
+++ b/src/components/JobSummary/TypeCount/TypeCount.js
@@ -18,7 +18,7 @@ const TypeCount = ({ stats }) => {
     if (stats.length == 0) return null
     return (
         <FormField
-            label={`${i18n.t('Type count')}`}
+            label={`${i18n.t('Details by type')}`}
             dataTest="job-summary-type-count"
             name="typeCount"
         >

--- a/src/components/JobSummary/TypeReportSummary/TypeReportSummary.js
+++ b/src/components/JobSummary/TypeReportSummary/TypeReportSummary.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import i18n from '@dhis2/d2-i18n'
 
 import { statsPropType, messagesPropType } from '../helper'
 import { SingleSummary } from '../SingleSummary/SingleSummary'
@@ -10,10 +9,7 @@ import { Messages } from '../Messages/Messages'
 const TypeReportSummary = ({ overviewStats, stats, messages }) => {
     return (
         <div>
-            <SingleSummary
-                importCount={overviewStats}
-                id={i18n.t('Overview')}
-            />
+            <SingleSummary importCount={overviewStats} />
             <TypeCount stats={stats} />
             <Messages messages={messages} />
         </div>

--- a/src/components/JobSummary/__test__/JobSummary.test.js
+++ b/src/components/JobSummary/__test__/JobSummary.test.js
@@ -44,7 +44,7 @@ describe('summary for a GML job', () => {
 
     test('events are showing', () => {
         const { getByDataTest } = renderJobSummary(gmlJob, props)
-        const events = getByDataTest('job-summary-events')
+        const events = getByDataTest('job-summary-log')
         expect(events).toBeInTheDocument()
         expect(events).toBeVisible()
     })
@@ -70,7 +70,7 @@ describe('summary for a data import job with conflicts', () => {
     test('overview summary is showing', () => {
         const { getByDataTest } = renderJobSummary(dataJob, props)
         const overviewSummary = getByDataTest('job-summary-single-summary')
-        expect(overviewSummary).toHaveTextContent(i18n.t('Overview'))
+        expect(overviewSummary).toHaveTextContent(i18n.t('Summary'))
     })
 
     test('conflicts are showing', () => {
@@ -90,7 +90,7 @@ describe('summary for a data import job with conflicts', () => {
 
     test('events are showing', () => {
         const { getByDataTest } = renderJobSummary(dataJob, props)
-        const events = getByDataTest('job-summary-events')
+        const events = getByDataTest('job-summary-log')
         expect(events).toBeInTheDocument()
         expect(events).toBeVisible()
     })

--- a/src/components/JobSummary/__test__/Log.test.js
+++ b/src/components/JobSummary/__test__/Log.test.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { render } from 'test-utils'
 import '@testing-library/jest-dom/extend-expect'
 
-import { Events } from '../Events/Events'
+import { Log } from '../Log/Log'
 
 const props = {
     events: [
@@ -25,6 +25,6 @@ const props = {
 }
 
 it(`matches snapshot`, () => {
-    const { asFragment } = render(<Events {...props} />)
+    const { asFragment } = render(<Log {...props} />)
     expect(asFragment()).toMatchSnapshot()
 })

--- a/src/components/JobSummary/__test__/__snapshots__/JobSummary.test.js.snap
+++ b/src/components/JobSummary/__test__/__snapshots__/JobSummary.test.js.snap
@@ -86,7 +86,7 @@ exports[`summary for a GML job matches snapshot 1`] = `
             <span
               class="label"
             >
-              Summary #Overview
+              Summary
             </span>
             <table
               class="jsx-2430604489 "
@@ -180,7 +180,7 @@ exports[`summary for a GML job matches snapshot 1`] = `
           <span
             class="label"
           >
-            Type count
+            Details by type
           </span>
           <table
             class="jsx-2430604489 "
@@ -362,12 +362,12 @@ exports[`summary for a GML job matches snapshot 1`] = `
     >
       <div
         class="container"
-        data-test="job-summary-events"
+        data-test="job-summary-log"
       >
         <span
           class="label"
         >
-          Events
+          Log
         </span>
         <table
           class="jsx-2430604489 "
@@ -598,7 +598,7 @@ exports[`summary for a data import job with conflicts matches snapshot 1`] = `
           <span
             class="label"
           >
-            Summary #Overview
+            Summary
           </span>
           <table
             class="jsx-2430604489 "
@@ -850,12 +850,12 @@ exports[`summary for a data import job with conflicts matches snapshot 1`] = `
     >
       <div
         class="container"
-        data-test="job-summary-events"
+        data-test="job-summary-log"
       >
         <span
           class="label"
         >
-          Events
+          Log
         </span>
         <table
           class="jsx-2430604489 "

--- a/src/components/JobSummary/__test__/__snapshots__/Log.test.js.snap
+++ b/src/components/JobSummary/__test__/__snapshots__/Log.test.js.snap
@@ -4,12 +4,12 @@ exports[`matches snapshot 1`] = `
 <DocumentFragment>
   <div
     class="container"
-    data-test="job-summary-events"
+    data-test="job-summary-log"
   >
     <span
       class="label"
     >
-      Events
+      Log
     </span>
     <table
       class="jsx-2430604489 "

--- a/src/components/JobSummary/__test__/__snapshots__/Summary.test.js.snap
+++ b/src/components/JobSummary/__test__/__snapshots__/Summary.test.js.snap
@@ -14,7 +14,7 @@ exports[`different job type summaries matches snapshot - DATAVALUE_IMPORT 1`] = 
         <span
           class="label"
         >
-          Summary #Overview
+          Summary
         </span>
         <table
           class="jsx-2430604489 "
@@ -170,7 +170,7 @@ exports[`different job type summaries matches snapshot - EVENT_IMPORT 1`] = `
         <span
           class="label"
         >
-          Summary #Overview
+          Summary
         </span>
         <table
           class="jsx-2430604489 "
@@ -468,7 +468,7 @@ exports[`different job type summaries matches snapshot - GML_IMPORT 1`] = `
           <span
             class="label"
           >
-            Summary #Overview
+            Summary
           </span>
           <table
             class="jsx-2430604489 "
@@ -562,7 +562,7 @@ exports[`different job type summaries matches snapshot - GML_IMPORT 1`] = `
         <span
           class="label"
         >
-          Type count
+          Details by type
         </span>
         <table
           class="jsx-2430604489 "
@@ -756,7 +756,7 @@ exports[`different job type summaries matches snapshot - METADATA_IMPORT 1`] = `
         <span
           class="label"
         >
-          Summary #Overview
+          Summary
         </span>
         <table
           class="jsx-2430604489 "

--- a/src/components/JobSummary/__test__/__snapshots__/TypeCount.test.js.snap
+++ b/src/components/JobSummary/__test__/__snapshots__/TypeCount.test.js.snap
@@ -9,7 +9,7 @@ exports[`matches snapshot 1`] = `
     <span
       class="label"
     >
-      Type count
+      Details by type
     </span>
     <table
       class="jsx-2430604489 "

--- a/src/components/JobSummary/__test__/__snapshots__/TypeReportSummary.test.js.snap
+++ b/src/components/JobSummary/__test__/__snapshots__/TypeReportSummary.test.js.snap
@@ -11,7 +11,7 @@ exports[`matches snapshot 1`] = `
         <span
           class="label"
         >
-          Summary #Overview
+          Summary
         </span>
         <table
           class="jsx-2430604489 "
@@ -105,7 +105,7 @@ exports[`matches snapshot 1`] = `
       <span
         class="label"
       >
-        Type count
+        Details by type
       </span>
       <table
         class="jsx-2430604489 "

--- a/src/components/Page/__snapshots__/Page.test.js.snap
+++ b/src/components/Page/__snapshots__/Page.test.js.snap
@@ -222,7 +222,7 @@ exports[`matches snapshot when not loading and a full summary task 1`] = `
               <span
                 class="label"
               >
-                Summary #Overview
+                Summary
               </span>
               <table
                 class="jsx-2430604489 "
@@ -366,12 +366,12 @@ exports[`matches snapshot when not loading and a full summary task 1`] = `
         >
           <div
             class="container"
-            data-test="job-summary-events"
+            data-test="job-summary-log"
           >
             <span
               class="label"
             >
-              Events
+              Log
             </span>
             <table
               class="jsx-2430604489 "

--- a/src/pages/JobOverview/JobOverview.js
+++ b/src/pages/JobOverview/JobOverview.js
@@ -13,8 +13,14 @@ const JobOverview = () => {
     const { jobOverview, updateJobOverview } = useContext(TaskContext)
 
     const setActiveTypes = types => {
+        const selectedJob = jobOverview.selectedJob
+        const job =
+            selectedJob && types.includes(selectedJob.importType)
+                ? selectedJob
+                : null
         updateJobOverview({
             activeTypes: types,
+            selectedJob: job,
         })
     }
     const setSelectedJob = job => {


### PR DESCRIPTION
- Changes title of main summary table from `Summary #Overview` to `Summary`
- Renames `Events` to `Log`
- Renames `Type count` to `Details by type`
- If user filters out the import job category of the selected job, the selected job is deselected and not shown on the page

These changes were discussed with Joe, Gintare and Phil.

---
Other improvements:
- Shows longer filenames on larger screens (truncate text with CSS)
- Single column layout on screens < 1200px (menu top, summary bottom)