### PR TITLE
fix: avoid app crash when GeoJSON file is invalid

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2022-09-07T13:45:08.268Z\n"
-"PO-Revision-Date: 2022-09-07T13:45:08.268Z\n"
+"POT-Creation-Date: 2022-09-13T11:01:01.500Z\n"
+"PO-Revision-Date: 2022-09-13T11:01:01.500Z\n"
 
 msgid "Something went wrong when loading the current user!"
 msgstr "Something went wrong when loading the current user!"
@@ -880,16 +880,6 @@ msgstr "No match found"
 
 msgid "Choose category option combo"
 msgstr "Choose category option combo"
-
-msgid "{{count}} org units"
-msgid_plural "{{count}} org units"
-msgstr[0] "{{count}} org unit"
-msgstr[1] "{{count}} org units"
-
-msgid "{{count}} levels"
-msgid_plural "{{count}} levels"
-msgstr[0] "{{count}} level"
-msgstr[1] "{{count}} levels"
 
 msgid "Selected: {{commaSeparatedListOfOrganisationUnits}}"
 msgstr "Selected: {{commaSeparatedListOfOrganisationUnits}}"

--- a/src/components/JobSummary/SingleSummary/SingleSummary.js
+++ b/src/components/JobSummary/SingleSummary/SingleSummary.js
@@ -82,7 +82,7 @@ const SingleSummary = ({
                                 <TableCell>
                                     {importType !== 'GEOJSON_IMPORT'
                                         ? c.object
-                                        : c.indexes.join(',')}
+                                        : (c.indexes || []).join(',')}
                                 </TableCell>
                                 <TableCell>{c.value}</TableCell>
                             </TableRow>


### PR DESCRIPTION
This PR avoids an app crash when the API response don't include an indexes array for conflicts in the response.  

Fixes: https://dhis2.atlassian.net/browse/DHIS2-7171?focusedCommentId=175417

After this PR the API error is shown: 

![Screenshot 2022-09-13 at 14 00 39](https://user-images.githubusercontent.com/548708/189895606-c6357779-78b6-485e-af96-950ba92942df.png)

Before this PR the app would crash if the GeoJSON is invalid: 

![Screenshot 2022-09-13 at 12 53 07](https://user-images.githubusercontent.com/548708/189895841-786e7ab9-ee0c-4f24-9e34-9fcfe12a606c.png)
