### PR TITLE
fix: geojson property name should match input field (DHIS2-7171)

### DIFF
--- a/src/components/Geometry/GeometryPropertyMatch.js
+++ b/src/components/Geometry/GeometryPropertyMatch.js
@@ -13,7 +13,7 @@ const MATCH_PROPERTY_LABEL = i18n.t(
 )
 const MATCH_PROPERTY_DATATEST = 'input-match-property'
 
-const NAME = 'geometryProperty'
+const NAME = 'geojsonProperty'
 const DATATEST = 'input-geometry-property'
 const LABEL = i18n.t('GeoJSON property name')
 const HELPTEXT = i18n.t(


### PR DESCRIPTION
This PR fixes an issue with the new GeoJSON importer where GeoJSON property name and the organisation unit id scheme is not included in the API url.

Fixes: https://dhis2.atlassian.net/browse/DHIS2-7171?focusedCommentId=175415

After this PR it is possible to match any GeoJSON property: 

![Screenshot 2022-09-13 at 16 27 40](https://user-images.githubusercontent.com/548708/189928009-78e5d61d-9297-43fc-a8f6-49452ae9dfa8.png)

Before it would show an error (because of fallback to feature id which is not present):

![Screenshot 2022-09-13 at 16 29 32](https://user-images.githubusercontent.com/548708/189928420-2c354a5a-a3ac-4321-bcb7-ada59fd8bde7.png)
