### PR TITLE
fix: use convention for page summary text

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2022-09-15T10:24:14.061Z\n"
-"PO-Revision-Date: 2022-09-15T10:24:14.061Z\n"
+"POT-Creation-Date: 2022-09-20T08:16:34.857Z\n"
+"PO-Revision-Date: 2022-09-20T08:16:34.857Z\n"
 
 msgid "Something went wrong when loading the current user!"
 msgstr "Something went wrong when loading the current user!"
@@ -832,6 +832,9 @@ msgstr "Organisation units"
 msgid "Import setup"
 msgstr "Import setup"
 
+msgid "Data preview"
+msgstr "Data preview"
+
 msgid "Some required fields are missing"
 msgstr "Some required fields are missing"
 
@@ -896,6 +899,9 @@ msgstr "Deselect all"
 msgid "Organisation unit(s) to import data to"
 msgstr "Organisation unit(s) to import data to"
 
+msgid "You must select an Earth Engine data set before selecting a period"
+msgstr "You must select an Earth Engine data set before selecting a period"
+
 msgid "Period"
 msgstr "Period"
 
@@ -926,8 +932,11 @@ msgstr "Current value"
 msgid "New value"
 msgstr "New value"
 
-msgid "Select rows per page"
-msgstr "Select rows per page"
+msgid "Rows per page"
+msgstr "Rows per page"
+
+msgid "Page {{page}} of {{pageCount}}, row {{firstItem}}-{{lastItem}} of {{total}}"
+msgstr "Page {{page}} of {{pageCount}}, row {{firstItem}}-{{lastItem}} of {{total}}"
 
 msgid "Don't round source values"
 msgstr "Don't round source values"

--- a/src/pages/EarthEngineImport/components/PopulationAgegroupsDataPreview.js
+++ b/src/pages/EarthEngineImport/components/PopulationAgegroupsDataPreview.js
@@ -181,9 +181,7 @@ const PopulationAgegroupsDataPreview = ({ eeData, pointOuRows }) => {
                                     onPageChange={setPageNo}
                                     onPageSizeChange={updateTable}
                                     pageSize={rowsPerPage}
-                                    pageSizeSelectText={i18n.t(
-                                        'Select rows per page'
-                                    )}
+                                    pageSizeSelectText={i18n.t('Rows per page')}
                                     total={tableData.length}
                                     pageLength={
                                         isLastPage()
@@ -191,6 +189,24 @@ const PopulationAgegroupsDataPreview = ({ eeData, pointOuRows }) => {
                                             : null
                                     }
                                     pageCount={getNumPages()}
+                                    pageSummaryText={({
+                                        firstItem,
+                                        lastItem,
+                                        page,
+                                        pageCount,
+                                        total,
+                                    }) =>
+                                        i18n.t(
+                                            'Page {{page}} of {{pageCount}}, row {{firstItem}}-{{lastItem}} of {{total}}',
+                                            {
+                                                firstItem,
+                                                lastItem,
+                                                page,
+                                                pageCount,
+                                                total,
+                                            }
+                                        )
+                                    }
                                 />
                             </div>
                         </DataTableCell>

--- a/src/pages/EarthEngineImport/components/PopulationDataPreview.js
+++ b/src/pages/EarthEngineImport/components/PopulationDataPreview.js
@@ -126,9 +126,7 @@ const PopulationDataPreview = ({ eeData, pointOuRows }) => {
                                     onPageChange={setPageNo}
                                     onPageSizeChange={updateTable}
                                     pageSize={rowsPerPage}
-                                    pageSizeSelectText={i18n.t(
-                                        'Select rows per page'
-                                    )}
+                                    pageSizeSelectText={i18n.t('Rows per page')}
                                     total={tableData.length}
                                     pageLength={
                                         isLastPage()
@@ -136,6 +134,24 @@ const PopulationDataPreview = ({ eeData, pointOuRows }) => {
                                             : null
                                     }
                                     pageCount={getNumPages()}
+                                    pageSummaryText={({
+                                        firstItem,
+                                        lastItem,
+                                        page,
+                                        pageCount,
+                                        total,
+                                    }) =>
+                                        i18n.t(
+                                            'Page {{page}} of {{pageCount}}, row {{firstItem}}-{{lastItem}} of {{total}}',
+                                            {
+                                                firstItem,
+                                                lastItem,
+                                                page,
+                                                pageCount,
+                                                total,
+                                            }
+                                        )
+                                    }
                                 />
                             </div>
                         </DataTableCell>


### PR DESCRIPTION
The text matches that of line-listing-app. Note that the ee importer has information about total rows and pages, so that is displayed in addition, unlike line-listing-app where this info is not available.
![image](https://user-images.githubusercontent.com/6113918/191204427-53ae94b2-6126-48b9-baf6-5eb8c0ef8273.png)


Line-listing app for reference:

![image](https://user-images.githubusercontent.com/6113918/191204747-421bae3c-ab00-4d9a-bce3-2f203bc6e2ab.png)

This PR also includes a pot file entry from another PR where the pot file was forgotten.
