### PR TITLE
fix: preserve users preferred rows per page for data preview [v39]

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2022-09-20T08:16:34.857Z\n"
-"PO-Revision-Date: 2022-09-20T08:16:34.857Z\n"
+"POT-Creation-Date: 2022-09-20T12:27:39.828Z\n"
+"PO-Revision-Date: 2022-09-20T12:27:39.828Z\n"
 
 msgid "Something went wrong when loading the current user!"
 msgstr "Something went wrong when loading the current user!"
@@ -803,19 +803,6 @@ msgstr "Import data values from ADX XML, DXF 2 XML, JSON, CSV or PDF files."
 msgid "Supported file types: JSON, CSV, XML, ADX and PDF."
 msgstr "Supported file types: JSON, CSV, XML, ADX and PDF."
 
-msgid "An error occurred while trying to fetch Earth Engine data"
-msgstr "An error occurred while trying to fetch Earth Engine data"
-
-msgid ""
-"The Earth Engine data set is too large. Try reducing the number of groups "
-"or organisation units"
-msgstr ""
-"The Earth Engine data set is too large. Try reducing the number of groups "
-"or organisation units"
-
-msgid "The organisation units selection is invalid"
-msgstr "The organisation units selection is invalid"
-
 msgid ""
 "Import WorldPop population data from Google Earth Engine to a DHIS2 data "
 "element"
@@ -964,6 +951,19 @@ msgstr "Round to 6 decimal places"
 
 msgid "Value rounding"
 msgstr "Value rounding"
+
+msgid "An error occurred while trying to fetch Earth Engine data"
+msgstr "An error occurred while trying to fetch Earth Engine data"
+
+msgid ""
+"The Earth Engine data set is too large. Try reducing the number of groups "
+"or organisation units"
+msgstr ""
+"The Earth Engine data set is too large. Try reducing the number of groups "
+"or organisation units"
+
+msgid "The organisation units selection is invalid"
+msgstr "The organisation units selection is invalid"
 
 msgid "The app could not retrieve required data."
 msgstr "The app could not retrieve required data."

--- a/src/pages/EarthEngineImport/EarthEngineImportForm.js
+++ b/src/pages/EarthEngineImport/EarthEngineImportForm.js
@@ -216,15 +216,16 @@ const EarthEngineImportForm = () => {
                                             modifiedSinceLastSubmit: true,
                                         }}
                                     >
-                                        {({ modifiedSinceLastSubmit }) =>
-                                            !modifiedSinceLastSubmit ? (
-                                                <DataPreview
-                                                    loading={loading}
-                                                    eeData={eeData}
-                                                    pointOuRows={pointOuRows}
-                                                />
-                                            ) : null
-                                        }
+                                        {({ modifiedSinceLastSubmit }) => (
+                                            <DataPreview
+                                                modifiedSinceLastSubmit={
+                                                    modifiedSinceLastSubmit
+                                                }
+                                                loading={loading}
+                                                eeData={eeData}
+                                                pointOuRows={pointOuRows}
+                                            />
+                                        )}
                                     </FormSpy>
                                     <FormSpy
                                         subscription={{

--- a/src/pages/EarthEngineImport/components/DataPreview.js
+++ b/src/pages/EarthEngineImport/components/DataPreview.js
@@ -5,7 +5,7 @@ import {
     CircularLoader,
 } from '@dhis2/ui'
 import PropTypes from 'prop-types'
-import React from 'react'
+import React, { useState } from 'react'
 import { POPULATION_DATASET_ID } from '../util/earthEngines.js'
 import { EARTH_ENGINE_ID } from '../util/formFieldConstants.js'
 import { PopulationAgegroupsDataPreview } from './PopulationAgegroupsDataPreview.js'
@@ -14,9 +14,21 @@ import styles from './styles/DataPreview.module.css'
 
 const { useField } = ReactFinalForm
 
-const DataPreview = ({ loading, eeData, pointOuRows }) => {
+const DEFAULT_ROWS_PER_PAGE = 10
+
+const DataPreview = ({
+    loading,
+    eeData,
+    pointOuRows,
+    modifiedSinceLastSubmit,
+}) => {
+    const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_ROWS_PER_PAGE)
     const { input } = useField(EARTH_ENGINE_ID)
     const { value: earthEngineId } = input
+
+    if (modifiedSinceLastSubmit) {
+        return null
+    }
 
     if (!loading && !eeData.length) {
         return null
@@ -38,11 +50,19 @@ const DataPreview = ({ loading, eeData, pointOuRows }) => {
                         <PopulationDataPreview
                             eeData={eeData}
                             pointOuRows={pointOuRows}
+                            rowsPerPage={rowsPerPage}
+                            onRowsPerPageChanged={(rows) =>
+                                setRowsPerPage(rows)
+                            }
                         />
                     ) : (
                         <PopulationAgegroupsDataPreview
                             eeData={eeData}
                             pointOuRows={pointOuRows}
+                            rowsPerPage={rowsPerPage}
+                            onRowsPerPageChanged={(rows) =>
+                                setRowsPerPage(rows)
+                            }
                         />
                     )}
                 </div>
@@ -54,6 +74,7 @@ const DataPreview = ({ loading, eeData, pointOuRows }) => {
 DataPreview.propTypes = {
     eeData: PropTypes.array,
     loading: PropTypes.bool,
+    modifiedSinceLastSubmit: PropTypes.bool,
     pointOuRows: PropTypes.array,
 }
 

--- a/src/pages/EarthEngineImport/components/DataPreview.js
+++ b/src/pages/EarthEngineImport/components/DataPreview.js
@@ -27,7 +27,7 @@ const DataPreview = ({
     const { input } = useField(EARTH_ENGINE_ID)
     const { value: earthEngineId } = input
 
-    const updateTable = (rows) => {
+    const updateTablePaging = (rows) => {
         setPageNo(1)
         setRowsPerPage(rows)
     }
@@ -58,7 +58,7 @@ const DataPreview = ({
                             pointOuRows={pointOuRows}
                             rowsPerPage={rowsPerPage}
                             pageNo={pageNo}
-                            onRowsPerPageChanged={updateTable}
+                            onRowsPerPageChanged={updateTablePaging}
                             onPageChanged={(n) => setPageNo(n)}
                         />
                     ) : (
@@ -67,7 +67,7 @@ const DataPreview = ({
                             pointOuRows={pointOuRows}
                             rowsPerPage={rowsPerPage}
                             pageNo={pageNo}
-                            onRowsPerPageChanged={updateTable}
+                            onRowsPerPageChanged={updateTablePaging}
                             onPageChanged={(n) => setPageNo(n)}
                         />
                     )}

--- a/src/pages/EarthEngineImport/components/DataPreview.js
+++ b/src/pages/EarthEngineImport/components/DataPreview.js
@@ -23,8 +23,14 @@ const DataPreview = ({
     modifiedSinceLastSubmit,
 }) => {
     const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_ROWS_PER_PAGE)
+    const [pageNo, setPageNo] = useState(1)
     const { input } = useField(EARTH_ENGINE_ID)
     const { value: earthEngineId } = input
+
+    const updateTable = (rows) => {
+        setPageNo(1)
+        setRowsPerPage(rows)
+    }
 
     if (modifiedSinceLastSubmit) {
         return null
@@ -51,18 +57,18 @@ const DataPreview = ({
                             eeData={eeData}
                             pointOuRows={pointOuRows}
                             rowsPerPage={rowsPerPage}
-                            onRowsPerPageChanged={(rows) =>
-                                setRowsPerPage(rows)
-                            }
+                            pageNo={pageNo}
+                            onRowsPerPageChanged={updateTable}
+                            onPageChanged={(n) => setPageNo(n)}
                         />
                     ) : (
                         <PopulationAgegroupsDataPreview
                             eeData={eeData}
                             pointOuRows={pointOuRows}
                             rowsPerPage={rowsPerPage}
-                            onRowsPerPageChanged={(rows) =>
-                                setRowsPerPage(rows)
-                            }
+                            pageNo={pageNo}
+                            onRowsPerPageChanged={updateTable}
+                            onPageChanged={(n) => setPageNo(n)}
                         />
                     )}
                 </div>

--- a/src/pages/EarthEngineImport/components/MapGenderAgeGroupsTable.js
+++ b/src/pages/EarthEngineImport/components/MapGenderAgeGroupsTable.js
@@ -32,7 +32,6 @@ const MappingTable = () => {
     const { push, update, pop } = form.mutators
 
     useEffect(() => {
-        console.log('effect 1')
         getEarthEngineBands(POPULATION_AGE_GROUPS_DATASET_ID).forEach((band) =>
             push(BAND_COCS, {
                 bandId: band.id,
@@ -49,7 +48,7 @@ const MappingTable = () => {
                 pop(BAND_COCS)
             }
         }
-    }, [])
+    }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
     useEffect(() => {
         bandCocs &&

--- a/src/pages/EarthEngineImport/components/MapGenderAgeGroupsTable.js
+++ b/src/pages/EarthEngineImport/components/MapGenderAgeGroupsTable.js
@@ -32,6 +32,7 @@ const MappingTable = () => {
     const { push, update, pop } = form.mutators
 
     useEffect(() => {
+        console.log('effect 1')
         getEarthEngineBands(POPULATION_AGE_GROUPS_DATASET_ID).forEach((band) =>
             push(BAND_COCS, {
                 bandId: band.id,
@@ -48,7 +49,7 @@ const MappingTable = () => {
                 pop(BAND_COCS)
             }
         }
-    }, []) // eslint-disable-line react-hooks/exhaustive-deps
+    }, [])
 
     useEffect(() => {
         bandCocs &&

--- a/src/pages/EarthEngineImport/components/PopulationAgegroupsDataPreview.js
+++ b/src/pages/EarthEngineImport/components/PopulationAgegroupsDataPreview.js
@@ -27,7 +27,9 @@ const PopulationAgegroupsDataPreview = ({
     eeData,
     pointOuRows,
     rowsPerPage,
+    pageNo,
     onRowsPerPageChanged,
+    onPageChanged,
 }) => {
     const { values } = useFormState()
     const { dataElementId, bandCocs } = values
@@ -35,7 +37,6 @@ const PopulationAgegroupsDataPreview = ({
 
     const [tableData, setTableData] = useState([])
     const { currentValues, error } = useFetchCurrentValues()
-    const [pageNo, setPageNo] = useState(1)
     const tableRef = useRef(null)
 
     const bandCocMap = useMemo(() => {
@@ -103,11 +104,6 @@ const PopulationAgegroupsDataPreview = ({
 
     if (!tableData.length) {
         return null
-    }
-
-    const updateTable = (newRowsPerPage) => {
-        setPageNo(1)
-        onRowsPerPageChanged(newRowsPerPage)
     }
 
     const getNumPages = () => Math.ceil(tableData.length / rowsPerPage)
@@ -181,8 +177,8 @@ const PopulationAgegroupsDataPreview = ({
                                 <Pagination
                                     page={pageNo}
                                     isLastPage={isLastPage()}
-                                    onPageChange={setPageNo}
-                                    onPageSizeChange={updateTable}
+                                    onPageChange={onPageChanged}
+                                    onPageSizeChange={onRowsPerPageChanged}
                                     pageSize={rowsPerPage}
                                     pageSizeSelectText={i18n.t('Rows per page')}
                                     total={tableData.length}
@@ -229,8 +225,10 @@ const PopulationAgegroupsDataPreview = ({
 
 PopulationAgegroupsDataPreview.propTypes = {
     eeData: PropTypes.array,
+    pageNo: PropTypes.number,
     pointOuRows: PropTypes.array,
     rowsPerPage: PropTypes.number,
+    onPageChanged: PropTypes.func,
     onRowsPerPageChanged: PropTypes.func,
 }
 

--- a/src/pages/EarthEngineImport/components/PopulationAgegroupsDataPreview.js
+++ b/src/pages/EarthEngineImport/components/PopulationAgegroupsDataPreview.js
@@ -19,12 +19,16 @@ import { useCachedDataQuery } from '../util/CachedQueryProvider.js'
 import styles from './styles/DataPreview.module.css'
 import { useFetchCurrentValues } from './useFetchCurrentValues.js'
 
-const DEFAULT_ROWS_PER_PAGE = 10
 const NO_ROWS = []
 
 const { useFormState } = ReactFinalForm
 
-const PopulationAgegroupsDataPreview = ({ eeData, pointOuRows }) => {
+const PopulationAgegroupsDataPreview = ({
+    eeData,
+    pointOuRows,
+    rowsPerPage,
+    onRowsPerPageChanged,
+}) => {
     const { values } = useFormState()
     const { dataElementId, bandCocs } = values
     const { dataElements } = useCachedDataQuery()
@@ -32,7 +36,6 @@ const PopulationAgegroupsDataPreview = ({ eeData, pointOuRows }) => {
     const [tableData, setTableData] = useState([])
     const { currentValues, error } = useFetchCurrentValues()
     const [pageNo, setPageNo] = useState(1)
-    const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_ROWS_PER_PAGE)
     const tableRef = useRef(null)
 
     const bandCocMap = useMemo(() => {
@@ -104,7 +107,7 @@ const PopulationAgegroupsDataPreview = ({ eeData, pointOuRows }) => {
 
     const updateTable = (newRowsPerPage) => {
         setPageNo(1)
-        setRowsPerPage(newRowsPerPage)
+        onRowsPerPageChanged(newRowsPerPage)
     }
 
     const getNumPages = () => Math.ceil(tableData.length / rowsPerPage)
@@ -227,6 +230,8 @@ const PopulationAgegroupsDataPreview = ({ eeData, pointOuRows }) => {
 PopulationAgegroupsDataPreview.propTypes = {
     eeData: PropTypes.array,
     pointOuRows: PropTypes.array,
+    rowsPerPage: PropTypes.number,
+    onRowsPerPageChanged: PropTypes.func,
 }
 
 export { PopulationAgegroupsDataPreview }

--- a/src/pages/EarthEngineImport/components/PopulationDataPreview.js
+++ b/src/pages/EarthEngineImport/components/PopulationDataPreview.js
@@ -23,11 +23,12 @@ const PopulationDataPreview = ({
     eeData,
     pointOuRows,
     rowsPerPage,
+    pageNo,
     onRowsPerPageChanged,
+    onPageChanged,
 }) => {
     const [tableData, setTableData] = useState([])
     const { currentValues, error } = useFetchCurrentValues()
-    const [pageNo, setPageNo] = useState(1)
     const tableRef = useRef(null)
 
     useEffect(() => {
@@ -68,10 +69,6 @@ const PopulationDataPreview = ({
 
     if (!tableData.length) {
         return null
-    }
-    const updateTable = (newRowsPerPage) => {
-        setPageNo(1)
-        onRowsPerPageChanged(newRowsPerPage)
     }
 
     const getNumPages = () => Math.ceil(tableData.length / rowsPerPage)
@@ -126,8 +123,8 @@ const PopulationDataPreview = ({
                                 <Pagination
                                     page={pageNo}
                                     isLastPage={isLastPage()}
-                                    onPageChange={setPageNo}
-                                    onPageSizeChange={updateTable}
+                                    onPageChange={onPageChanged}
+                                    onPageSizeChange={onRowsPerPageChanged}
                                     pageSize={rowsPerPage}
                                     pageSizeSelectText={i18n.t('Rows per page')}
                                     total={tableData.length}
@@ -174,8 +171,10 @@ const PopulationDataPreview = ({
 
 PopulationDataPreview.propTypes = {
     eeData: PropTypes.array,
+    pageNo: PropTypes.number,
     pointOuRows: PropTypes.array,
     rowsPerPage: PropTypes.number,
+    onPageChanged: PropTypes.func,
     onRowsPerPageChanged: PropTypes.func,
 }
 

--- a/src/pages/EarthEngineImport/components/PopulationDataPreview.js
+++ b/src/pages/EarthEngineImport/components/PopulationDataPreview.js
@@ -17,14 +17,17 @@ import React, { useState, useEffect, useMemo, useRef } from 'react'
 import styles from './styles/DataPreview.module.css'
 import { useFetchCurrentValues } from './useFetchCurrentValues.js'
 
-const DEFAULT_ROWS_PER_PAGE = 10
 const NO_ROWS = []
 
-const PopulationDataPreview = ({ eeData, pointOuRows }) => {
+const PopulationDataPreview = ({
+    eeData,
+    pointOuRows,
+    rowsPerPage,
+    onRowsPerPageChanged,
+}) => {
     const [tableData, setTableData] = useState([])
     const { currentValues, error } = useFetchCurrentValues()
     const [pageNo, setPageNo] = useState(1)
-    const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_ROWS_PER_PAGE)
     const tableRef = useRef(null)
 
     useEffect(() => {
@@ -68,7 +71,7 @@ const PopulationDataPreview = ({ eeData, pointOuRows }) => {
     }
     const updateTable = (newRowsPerPage) => {
         setPageNo(1)
-        setRowsPerPage(newRowsPerPage)
+        onRowsPerPageChanged(newRowsPerPage)
     }
 
     const getNumPages = () => Math.ceil(tableData.length / rowsPerPage)
@@ -172,6 +175,8 @@ const PopulationDataPreview = ({ eeData, pointOuRows }) => {
 PopulationDataPreview.propTypes = {
     eeData: PropTypes.array,
     pointOuRows: PropTypes.array,
+    rowsPerPage: PropTypes.number,
+    onRowsPerPageChanged: PropTypes.func,
 }
 
 export { PopulationDataPreview }


### PR DESCRIPTION
Keep rows per page in state.

https://user-images.githubusercontent.com/6113918/191472049-9a3180f5-cc6a-43fe-8ba8-b4f55876dc76.mov


