### PR TITLE
fix: ee import - refactor to make sure all useEffect dependencies are listed [v39]

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2022-09-20T12:27:39.828Z\n"
-"PO-Revision-Date: 2022-09-20T12:27:39.828Z\n"
+"POT-Creation-Date: 2022-09-21T12:12:01.489Z\n"
+"PO-Revision-Date: 2022-09-21T12:12:01.489Z\n"
 
 msgid "Something went wrong when loading the current user!"
 msgstr "Something went wrong when loading the current user!"
@@ -834,21 +834,6 @@ msgstr "Use associated geometry"
 msgid "Select associated geometry for selected organisation units"
 msgstr "Select associated geometry for selected organisation units"
 
-msgid "Data element"
-msgstr "Data element"
-
-msgid "Select data element"
-msgstr "Select data element"
-
-msgid "The data element where Earth Engine data will be added"
-msgstr "The data element where Earth Engine data will be added"
-
-msgid "Earth Engine data set"
-msgstr "Earth Engine data set"
-
-msgid "Select earth engine data set"
-msgstr "Select earth engine data set"
-
 msgid "Import groups to category option combinations"
 msgstr "Import groups to category option combinations"
 
@@ -873,6 +858,21 @@ msgstr "No match found"
 
 msgid "Choose category option combo"
 msgstr "Choose category option combo"
+
+msgid "Data element"
+msgstr "Data element"
+
+msgid "Select data element"
+msgstr "Select data element"
+
+msgid "The data element where Earth Engine data will be added"
+msgstr "The data element where Earth Engine data will be added"
+
+msgid "Earth Engine data set"
+msgstr "Earth Engine data set"
+
+msgid "Select earth engine data set"
+msgstr "Select earth engine data set"
 
 msgid "Selected: {{commaSeparatedListOfOrganisationUnits}}"
 msgstr "Selected: {{commaSeparatedListOfOrganisationUnits}}"

--- a/src/pages/EarthEngineImport/components/BandCocMappingTable.js
+++ b/src/pages/EarthEngineImport/components/BandCocMappingTable.js
@@ -92,9 +92,8 @@ const BandCocMappingTable = () => {
                 </TableHead>
                 <TableBody>
                     <FieldArray name={BAND_COCS}>
-                        {({ fields }) => {
-                            console.log('fields.length', fields.length)
-                            return fields.map((name, i) => {
+                        {({ fields }) =>
+                            fields.map((name, i) => {
                                 return (
                                     <TableRow key={`row-${i}`}>
                                         <TableCell dense>
@@ -125,7 +124,7 @@ const BandCocMappingTable = () => {
                                     </TableRow>
                                 )
                             })
-                        }}
+                        }
                     </FieldArray>
                 </TableBody>
             </Table>

--- a/src/pages/EarthEngineImport/components/BandCocMappingTable.js
+++ b/src/pages/EarthEngineImport/components/BandCocMappingTable.js
@@ -33,6 +33,9 @@ const BandCocMappingTable = () => {
         }
     }, [change])
 
+    // dataElementId is a dependency because if it changes then
+    // the BAND_COCS mapping is no longer valid. The mapped
+    // cocs are specific to the dataElementId.
     useEffect(() => {
         const dataSetBands = getEarthEngineBands(earthEngineId)
         change(BAND_COCS, dataSetBands)

--- a/src/pages/EarthEngineImport/components/BandCocMappingTable.js
+++ b/src/pages/EarthEngineImport/components/BandCocMappingTable.js
@@ -11,7 +11,7 @@ import {
     NoticeBox,
     SingleSelectFieldFF,
 } from '@dhis2/ui'
-import React, { useState, useEffect, useMemo } from 'react'
+import React, { useState, useEffect } from 'react'
 import { FieldArray } from 'react-final-form-arrays'
 import { useCachedDataQuery } from '../util/CachedQueryProvider.js'
 import { getEarthEngineBands } from '../util/earthEngines.js'

--- a/src/pages/EarthEngineImport/components/DataPreview.js
+++ b/src/pages/EarthEngineImport/components/DataPreview.js
@@ -6,7 +6,7 @@ import {
 } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React, { useState } from 'react'
-import { POPULATION_DATASET_ID } from '../util/earthEngines.js'
+import { getEarthEngineBands } from '../util/earthEngines.js'
 import { EARTH_ENGINE_ID } from '../util/formFieldConstants.js'
 import { PopulationAgegroupsDataPreview } from './PopulationAgegroupsDataPreview.js'
 import { PopulationDataPreview } from './PopulationDataPreview.js'
@@ -52,7 +52,7 @@ const DataPreview = ({
                 </div>
             ) : (
                 <div className={styles.indent}>
-                    {earthEngineId === POPULATION_DATASET_ID ? (
+                    {!getEarthEngineBands(earthEngineId).length ? (
                         <PopulationDataPreview
                             eeData={eeData}
                             pointOuRows={pointOuRows}

--- a/src/pages/EarthEngineImport/components/PopulationAgegroupsDataPreview.js
+++ b/src/pages/EarthEngineImport/components/PopulationAgegroupsDataPreview.js
@@ -41,7 +41,7 @@ const PopulationAgegroupsDataPreview = ({
 
     const bandCocMap = useMemo(() => {
         return bandCocs.reduce((acc, curr) => {
-            acc[curr.bandId] = curr
+            acc[curr.id] = curr
             return acc
         }, {})
     }, [bandCocs])
@@ -61,7 +61,7 @@ const PopulationAgegroupsDataPreview = ({
         if (eeData) {
             const newArr = eeData
                 .map((d) => {
-                    const cocId = bandCocMap[d.bandId]?.coc
+                    const cocId = bandCocMap[d.id]?.coc
 
                     const current = currentValues
                         .filter((v) => v.orgUnit === d.ouId)

--- a/src/pages/EarthEngineImport/form-helper.js
+++ b/src/pages/EarthEngineImport/form-helper.js
@@ -25,9 +25,8 @@ const onImport =
                 dataElement,
                 period,
                 orgUnit: d[OU_ID],
-                categoryOptionCombo: bandCocs.find(
-                    (bc) => bc.bandId === d[BAND_ID]
-                ).coc,
+                categoryOptionCombo: bandCocs.find((bc) => bc.id === d[BAND_ID])
+                    .coc,
                 value: d[VALUE],
             }))
         } else {

--- a/src/pages/EarthEngineImport/util/earthEngines.js
+++ b/src/pages/EarthEngineImport/util/earthEngines.js
@@ -1,9 +1,8 @@
 import i18n from '@dhis2/d2-i18n'
 
-export const POPULATION_AGE_GROUPS_DATASET_ID =
+const POPULATION_DATASET_ID = 'WorldPop/GP/100m/pop'
+const POPULATION_AGE_GROUPS_DATASET_ID =
     'WorldPop/GP/100m/pop_age_sex_cons_unadj'
-
-export const POPULATION_DATASET_ID = 'WorldPop/GP/100m/pop'
 
 export const earthEngines = {
     [POPULATION_DATASET_ID]: {
@@ -208,7 +207,7 @@ export const earthEngines = {
 const NO_BANDS = []
 
 export const getEarthEngineBands = (eeId) =>
-    earthEngines[eeId].bands || NO_BANDS
+    earthEngines[eeId]?.bands || NO_BANDS
 
 export const getDefaultAggregation = (eeId) =>
     earthEngines[eeId].defaultAggregations[0]

--- a/src/pages/EarthEngineImport/util/getEarthEngineConfig.js
+++ b/src/pages/EarthEngineImport/util/getEarthEngineConfig.js
@@ -1,9 +1,6 @@
 import i18n from '@dhis2/d2-i18n'
 import { NO_ASSOCIATED_GEOMETRY } from '../components/AssociatedGeometry.js'
-import {
-    earthEngines,
-    POPULATION_AGE_GROUPS_DATASET_ID,
-} from './earthEngines.js'
+import { earthEngines, getEarthEngineBands } from './earthEngines.js'
 import { toGeoJson } from './toGeoJson.js'
 
 const getGeoFeaturesQuery = (ouIds, coordinateField) => ({
@@ -88,11 +85,8 @@ const getEarthEngineConfig = async (
         data: polygonFeatures,
     }
 
-    if (
-        earthEngineId === POPULATION_AGE_GROUPS_DATASET_ID &&
-        selectedBandCocs
-    ) {
-        cfg.band = selectedBandCocs.map((bc) => bc.bandId)
+    if (getEarthEngineBands(earthEngineId).length && selectedBandCocs) {
+        cfg.band = selectedBandCocs.map((bc) => bc.id)
     }
 
     const config = Object.fromEntries(

--- a/src/pages/EarthEngineImport/util/getStructuredData.js
+++ b/src/pages/EarthEngineImport/util/getStructuredData.js
@@ -20,7 +20,7 @@ const ALL_AGGREGATION_TYPES = [
 
 export const OU_ID = 'ouId'
 export const OU_NAME = 'ouName'
-export const BAND_ID = 'bandId'
+export const BAND_ID = 'id'
 export const COC_ID = 'coc'
 export const VALUE = 'value'
 
@@ -43,7 +43,7 @@ const getStructuredData = ({
             acc.push({
                 [OU_ID]: ouId,
                 [OU_NAME]: ouName,
-                [BAND_ID]: selectedBandCocs[0].bandId,
+                [BAND_ID]: selectedBandCocs[0].id,
                 [VALUE]: getValueWithPrecision(valueSet[aggregationType]),
             })
         } else if (selectedBandCocs.length > 1) {


### PR DESCRIPTION
Removed two //eslint-disable comments by refactoring the MappingTable component. 

I found that the `push` and `pop` from form.mutators don't seem to be memoized, as including them in the dependencies array was triggering the effect and causing bugs. Solution was to use form.change instead, which does seem to be memoized. This was also actually a cleaner solution as the effect now just sets the whole array of band-cocs to the array in the earthengine config (with props `id` and `name` instead of `bandId` and `bandName`).

Another refactor was to make the components agnostic as to which earth engine dataset is chosen. Instead of checking which dataset it is, the code checks whether the ee config has bands. This is a more flexible solution for when new ee datasets are added in the future.