### PR TITLE
fix: page number needs to be reset to 1 when new preview generated [v39]

### DIFF
--- a/src/pages/EarthEngineImport/components/DataPreview.js
+++ b/src/pages/EarthEngineImport/components/DataPreview.js
@@ -23,14 +23,8 @@ const DataPreview = ({
     modifiedSinceLastSubmit,
 }) => {
     const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_ROWS_PER_PAGE)
-    const [pageNo, setPageNo] = useState(1)
     const { input } = useField(EARTH_ENGINE_ID)
     const { value: earthEngineId } = input
-
-    const updateTablePaging = (rows) => {
-        setPageNo(1)
-        setRowsPerPage(rows)
-    }
 
     if (modifiedSinceLastSubmit) {
         return null
@@ -57,18 +51,14 @@ const DataPreview = ({
                             eeData={eeData}
                             pointOuRows={pointOuRows}
                             rowsPerPage={rowsPerPage}
-                            pageNo={pageNo}
-                            onRowsPerPageChanged={updateTablePaging}
-                            onPageChanged={(n) => setPageNo(n)}
+                            onRowsPerPageChanged={setRowsPerPage}
                         />
                     ) : (
                         <PopulationAgegroupsDataPreview
                             eeData={eeData}
                             pointOuRows={pointOuRows}
                             rowsPerPage={rowsPerPage}
-                            pageNo={pageNo}
-                            onRowsPerPageChanged={updateTablePaging}
-                            onPageChanged={(n) => setPageNo(n)}
+                            onRowsPerPageChanged={setRowsPerPage}
                         />
                     )}
                 </div>

--- a/src/pages/EarthEngineImport/components/PopulationAgegroupsDataPreview.js
+++ b/src/pages/EarthEngineImport/components/PopulationAgegroupsDataPreview.js
@@ -27,15 +27,14 @@ const PopulationAgegroupsDataPreview = ({
     eeData,
     pointOuRows,
     rowsPerPage,
-    pageNo,
     onRowsPerPageChanged,
-    onPageChanged,
 }) => {
     const { values } = useFormState()
     const { dataElementId, bandCocs } = values
     const { dataElements } = useCachedDataQuery()
 
     const [tableData, setTableData] = useState([])
+    const [pageNo, setPageNo] = useState(1)
     const { currentValues, error } = useFetchCurrentValues()
     const tableRef = useRef(null)
 
@@ -110,6 +109,11 @@ const PopulationAgegroupsDataPreview = ({
     const isLastPage = () => pageNo === getNumPages()
     const getLastPageLength = () => tableData.length % rowsPerPage
 
+    const updateTablePaging = (rows) => {
+        setPageNo(1)
+        onRowsPerPageChanged(rows)
+    }
+
     return (
         <div ref={tableRef}>
             <DataTable dense className={styles.table}>
@@ -177,8 +181,8 @@ const PopulationAgegroupsDataPreview = ({
                                 <Pagination
                                     page={pageNo}
                                     isLastPage={isLastPage()}
-                                    onPageChange={onPageChanged}
-                                    onPageSizeChange={onRowsPerPageChanged}
+                                    onPageChange={setPageNo}
+                                    onPageSizeChange={updateTablePaging}
                                     pageSize={rowsPerPage}
                                     pageSizeSelectText={i18n.t('Rows per page')}
                                     total={tableData.length}
@@ -225,10 +229,8 @@ const PopulationAgegroupsDataPreview = ({
 
 PopulationAgegroupsDataPreview.propTypes = {
     eeData: PropTypes.array,
-    pageNo: PropTypes.number,
     pointOuRows: PropTypes.array,
     rowsPerPage: PropTypes.number,
-    onPageChanged: PropTypes.func,
     onRowsPerPageChanged: PropTypes.func,
 }
 

--- a/src/pages/EarthEngineImport/components/PopulationAgegroupsDataPreview.js
+++ b/src/pages/EarthEngineImport/components/PopulationAgegroupsDataPreview.js
@@ -34,7 +34,7 @@ const PopulationAgegroupsDataPreview = ({
     const { dataElements } = useCachedDataQuery()
 
     const [tableData, setTableData] = useState([])
-    const [pageNo, setPageNo] = useState(1)
+    const [page, setPage] = useState(1)
     const { currentValues, error } = useFetchCurrentValues()
     const tableRef = useRef(null)
 
@@ -95,22 +95,22 @@ const PopulationAgegroupsDataPreview = ({
         if (!tableData.length) {
             return NO_ROWS
         }
-        const start = (pageNo - 1) * rowsPerPage
+        const start = (page - 1) * rowsPerPage
         const end = start + rowsPerPage
 
         return tableData.slice(start, end)
-    }, [tableData, rowsPerPage, pageNo])
+    }, [tableData, rowsPerPage, page])
 
     if (!tableData.length) {
         return null
     }
 
     const getNumPages = () => Math.ceil(tableData.length / rowsPerPage)
-    const isLastPage = () => pageNo === getNumPages()
+    const isLastPage = () => page === getNumPages()
     const getLastPageLength = () => tableData.length % rowsPerPage
 
     const updateTablePaging = (rows) => {
-        setPageNo(1)
+        setPage(1)
         onRowsPerPageChanged(rows)
     }
 
@@ -179,9 +179,9 @@ const PopulationAgegroupsDataPreview = ({
                         <DataTableCell staticStyle colSpan={'4'}>
                             <div>
                                 <Pagination
-                                    page={pageNo}
+                                    page={page}
                                     isLastPage={isLastPage()}
-                                    onPageChange={setPageNo}
+                                    onPageChange={setPage}
                                     onPageSizeChange={updateTablePaging}
                                     pageSize={rowsPerPage}
                                     pageSizeSelectText={i18n.t('Rows per page')}

--- a/src/pages/EarthEngineImport/components/PopulationDataPreview.js
+++ b/src/pages/EarthEngineImport/components/PopulationDataPreview.js
@@ -23,11 +23,10 @@ const PopulationDataPreview = ({
     eeData,
     pointOuRows,
     rowsPerPage,
-    pageNo,
     onRowsPerPageChanged,
-    onPageChanged,
 }) => {
     const [tableData, setTableData] = useState([])
+    const [pageNo, setPageNo] = useState(1)
     const { currentValues, error } = useFetchCurrentValues()
     const tableRef = useRef(null)
 
@@ -74,6 +73,11 @@ const PopulationDataPreview = ({
     const getNumPages = () => Math.ceil(tableData.length / rowsPerPage)
     const isLastPage = () => pageNo === getNumPages()
     const getLastPageLength = () => tableData.length % rowsPerPage
+
+    const updateTablePaging = (rows) => {
+        setPageNo(1)
+        onRowsPerPageChanged(rows)
+    }
 
     return (
         <div ref={tableRef}>
@@ -123,8 +127,8 @@ const PopulationDataPreview = ({
                                 <Pagination
                                     page={pageNo}
                                     isLastPage={isLastPage()}
-                                    onPageChange={onPageChanged}
-                                    onPageSizeChange={onRowsPerPageChanged}
+                                    onPageChange={setPageNo}
+                                    onPageSizeChange={updateTablePaging}
                                     pageSize={rowsPerPage}
                                     pageSizeSelectText={i18n.t('Rows per page')}
                                     total={tableData.length}
@@ -171,10 +175,8 @@ const PopulationDataPreview = ({
 
 PopulationDataPreview.propTypes = {
     eeData: PropTypes.array,
-    pageNo: PropTypes.number,
     pointOuRows: PropTypes.array,
     rowsPerPage: PropTypes.number,
-    onPageChanged: PropTypes.func,
     onRowsPerPageChanged: PropTypes.func,
 }
 

--- a/src/pages/EarthEngineImport/components/PopulationDataPreview.js
+++ b/src/pages/EarthEngineImport/components/PopulationDataPreview.js
@@ -26,7 +26,7 @@ const PopulationDataPreview = ({
     onRowsPerPageChanged,
 }) => {
     const [tableData, setTableData] = useState([])
-    const [pageNo, setPageNo] = useState(1)
+    const [page, setPage] = useState(1)
     const { currentValues, error } = useFetchCurrentValues()
     const tableRef = useRef(null)
 
@@ -60,22 +60,22 @@ const PopulationDataPreview = ({
         if (!tableData.length) {
             return NO_ROWS
         }
-        const start = (pageNo - 1) * rowsPerPage
+        const start = (page - 1) * rowsPerPage
         const end = start + rowsPerPage
 
         return tableData.slice(start, end)
-    }, [tableData, rowsPerPage, pageNo])
+    }, [tableData, rowsPerPage, page])
 
     if (!tableData.length) {
         return null
     }
 
     const getNumPages = () => Math.ceil(tableData.length / rowsPerPage)
-    const isLastPage = () => pageNo === getNumPages()
+    const isLastPage = () => page === getNumPages()
     const getLastPageLength = () => tableData.length % rowsPerPage
 
     const updateTablePaging = (rows) => {
-        setPageNo(1)
+        setPage(1)
         onRowsPerPageChanged(rows)
     }
 
@@ -125,9 +125,9 @@ const PopulationDataPreview = ({
                         <DataTableCell staticStyle colSpan={'3'}>
                             <div>
                                 <Pagination
-                                    page={pageNo}
+                                    page={page}
                                     isLastPage={isLastPage()}
-                                    onPageChange={setPageNo}
+                                    onPageChange={setPage}
                                     onPageSizeChange={updateTablePaging}
                                     pageSize={rowsPerPage}
                                     pageSizeSelectText={i18n.t('Rows per page')}


### PR DESCRIPTION
Do not persist the page number because it may become invalid when the preview is regenerated and there are fewer rows of data. Therefore, put the pageNo into the state for the components that are removed every time the preview is generated.

Side note: the two Population Preview components could probably be refactored since about 80% of the code is identical. But that will have to be done for a later version.