### PR TITLE
fix: do not scroll to preview table during form submit

### DIFF
--- a/src/pages/EarthEngineImport/components/PopulationAgegroupsDataPreview.js
+++ b/src/pages/EarthEngineImport/components/PopulationAgegroupsDataPreview.js
@@ -37,13 +37,22 @@ const PopulationAgegroupsDataPreview = ({
     const [page, setPage] = useState(1)
     const { currentValues, error } = useFetchCurrentValues()
     const tableRef = useRef(null)
+    const [bandCocMap, setBandCocMap] = useState({})
 
-    const bandCocMap = useMemo(() => {
-        return bandCocs.reduce((acc, curr) => {
-            acc[curr.id] = curr
-            return acc
-        }, {})
-    }, [bandCocs])
+    useEffect(() => {
+        // Unfortunately bandCocs from react-final-form-array does
+        // not preserve referential equality even though the values
+        // in the array are the same. Since this component
+        // will be unmounted if bandCocs actually changes, it is safe
+        // to only set the bandCocMap once when being initialized
+        if (!Object.keys(bandCocMap).length) {
+            const bcocMap = bandCocs.reduce((acc, curr) => {
+                acc[curr.id] = curr
+                return acc
+            }, {})
+            setBandCocMap(bcocMap)
+        }
+    }, [bandCocs, bandCocMap])
 
     const cocMap = useMemo(() => {
         const cocs =


### PR DESCRIPTION
Fixes https://dhis2.atlassian.net/browse/DHIS2-13862

What was happening: there are competing scroll triggers - one for the main form that should scroll the entire form up to the top so user is shown the Job Summary, and the other for scrolling down to the data preview table when the user clicks the Preview button.

Before this fix, the effect for scrolling to the data preview was triggering when it shouldn't because bandCocs is never referentially equal, causing useMemo to trigger with every render. This then causes the data preview scroll to trigger after the Job Summary scroll.