### PR TITLE
fix: use correct metadata update strategy [DHIS-12479]  

### DIFF
--- a/src/components/Inputs/ImportStrategy.js
+++ b/src/components/Inputs/ImportStrategy.js
@@ -16,7 +16,7 @@ const importStrategyOptions = [
         prefix: i18n.t('Append'),
     },
     {
-        value: 'UPDATES',
+        value: 'UPDATE',
         label: i18n.t('Only update existing values, ignore new values'),
         prefix: i18n.t('Update'),
     },


### PR DESCRIPTION
Hi Team, 

Raising this PR to fix the following bug 
https://dhis2.atlassian.net/browse/DHIS2-12479

The error is due to null pointer exception in the backend when strategy is "UPDATES". As per the backend logic, it is expecting "UPDATE" as strategy.  

Thanks,
Rithvik