### PR TITLE
fix: use correct update strategy for metadata import [DHIS-12479]

### DIFF
--- a/src/components/Inputs/ImportStrategy.js
+++ b/src/components/Inputs/ImportStrategy.js
@@ -16,7 +16,7 @@ const importStrategyOptions = [
         prefix: i18n.t('Append'),
     },
     {
-        value: 'UPDATES',
+        value: 'UPDATE',
         label: i18n.t('Only update existing values, ignore new values'),
         prefix: i18n.t('Update'),
     },


### PR DESCRIPTION
This recreates PR https://github.com/dhis2/import-export-app/pull/1651

(we need to look into updating some of our CI workflows to make them runnable from external forks (see [DHIS2-14677](https://dhis2.atlassian.net/browse/DHIS2-14677)), hence the temporary need to recreate)

[DHIS2-14677]: https://dhis2.atlassian.net/browse/DHIS2-14677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ