### PR TITLE
fix: use same dataset for total population and age-group population

### DIFF
--- a/src/pages/EarthEngineImport/components/EarthEngineId.js
+++ b/src/pages/EarthEngineImport/components/EarthEngineId.js
@@ -5,9 +5,9 @@ import { StyledField } from '../../../components/index.js'
 import { earthEngines } from '../util/earthEngines.js'
 import { EARTH_ENGINE_ID } from '../util/formFieldConstants.js'
 
-const eeList = Object.values(earthEngines).map(({ name, datasetId }) => ({
+const options = Object.values(earthEngines).map(({ name, earthEngineId }) => ({
     label: name,
-    value: datasetId,
+    value: earthEngineId,
 }))
 
 const EarthEngineId = () => (
@@ -16,7 +16,7 @@ const EarthEngineId = () => (
             component={SingleSelectFieldFF}
             name={EARTH_ENGINE_ID}
             label={i18n.t('Earth Engine data set')}
-            options={eeList}
+            options={options}
             dataTest="input-earthengine-id"
             placeholder={i18n.t('Select earth engine data set')}
             filled

--- a/src/pages/EarthEngineImport/util/earthEngineHelper.js
+++ b/src/pages/EarthEngineImport/util/earthEngineHelper.js
@@ -62,7 +62,7 @@ export const getPeriods = async (eeId, engine) => {
     }
 
     const eeWorker = await getWorkerInstance(engine)
-    const { features } = await eeWorker.getPeriods(eeId)
+    const { features } = await eeWorker.getPeriods(earthEngines[eeId].datasetId)
 
     const periods = features.map(getPeriod).map((p) => {
         const period = filters ? filters(p)[0] : p

--- a/src/pages/EarthEngineImport/util/earthEngines.js
+++ b/src/pages/EarthEngineImport/util/earthEngines.js
@@ -1,20 +1,26 @@
 import i18n from '@dhis2/d2-i18n'
 
-const POPULATION_DATASET_ID = 'WorldPop/GP/100m/pop'
+const POPULATION_TOTAL_EE_ID = 'WorldPop/GP/100m/pop_age_sex_cons_unadj_TOTAL'
+const POPULATION_AGE_GROUPS_EE_ID =
+    'WorldPop/GP/100m/pop_age_sex_cons_unadj_AGE_GROUPS'
 const POPULATION_AGE_GROUPS_DATASET_ID =
     'WorldPop/GP/100m/pop_age_sex_cons_unadj'
+const SOURCE_NAME = 'WorldPop / Google Earth Engine'
+const SOURCE_URL =
+    'https://developers.google.com/earth-engine/datasets/catalog/WorldPop_GP_100m_pop_age_sex_cons_unadj'
 
 export const earthEngines = {
-    [POPULATION_DATASET_ID]: {
-        datasetId: POPULATION_DATASET_ID,
+    [POPULATION_TOTAL_EE_ID]: {
+        earthEngineId: POPULATION_TOTAL_EE_ID,
+        datasetId: POPULATION_AGE_GROUPS_DATASET_ID,
         name: i18n.t('Population'),
-        source: 'WorldPop / Google Earth Engine',
-        sourceUrl:
-            'https://developers.google.com/earth-engine/datasets/catalog/WorldPop_GP_100m_pop',
+        source: SOURCE_NAME,
+        sourceUrl: SOURCE_URL,
         img: 'images/population.png',
         defaultAggregations: ['sum', 'mean'],
         periodType: 'Yearly',
         bandReducer: 'sum',
+        band: 'population',
         filters: ({ id, name, year }) => [
             {
                 id,
@@ -26,16 +32,16 @@ export const earthEngines = {
         mosaic: true,
         params: {
             min: 0,
-            max: 10,
+            max: 25,
             palette: '#fee5d9,#fcbba1,#fc9272,#fb6a4a,#de2d26,#a50f15', // Reds
         },
     },
-    [POPULATION_AGE_GROUPS_DATASET_ID]: {
+    [POPULATION_AGE_GROUPS_EE_ID]: {
+        earthEngineId: POPULATION_AGE_GROUPS_EE_ID,
         datasetId: POPULATION_AGE_GROUPS_DATASET_ID,
         name: i18n.t('Population age groups'),
-        source: 'WorldPop / Google Earth Engine',
-        sourceUrl:
-            'https://developers.google.com/earth-engine/datasets/catalog/WorldPop_GP_100m_pop_age_sex_cons_unadj',
+        source: SOURCE_NAME,
+        sourceUrl: SOURCE_URL,
         img: 'images/population.png',
         periodType: 'Yearly',
         bandReducer: 'sum',


### PR DESCRIPTION
Related to: https://dhis2.atlassian.net/browse/DHIS2-14282

We now use the same Earth Engine dataset for both total population and age/gender groups. This ensures that the total population numbers are the same.

There is now only one period for Total population: 2020

![image](https://user-images.githubusercontent.com/6113918/231484275-abb7182c-5f3c-4c02-a697-e818a367faa3.png)
