### PR TITLE
fix: use string for date inputs [DHIS2-12489]

### DIFF
--- a/src/components/DatePicker/DatePicker.js
+++ b/src/components/DatePicker/DatePicker.js
@@ -1,24 +1,15 @@
 import { InputField } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React from 'react'
-import { jsDateToISO8601 } from '../../utils/helper.js'
 
 const DatePicker = ({ name, error, label, date, onChange, dataTest }) => {
-    const onChangeHelper = ({ value }) => {
-        if (!value) {
-            onChange(value)
-        } else {
-            onChange(new Date(value))
-        }
-    }
-
-    const value = date && jsDateToISO8601(date)
+    const onChangeHelper = ({ value }) => onChange(value)
 
     return (
         <InputField
             type="date"
             name={name}
-            value={value}
+            value={date}
             label={label}
             onChange={onChangeHelper}
             inputWidth="200px"

--- a/src/components/DatePicker/DatePicker.test.js
+++ b/src/components/DatePicker/DatePicker.test.js
@@ -8,7 +8,7 @@ const props = {
     dataTest: 'date-picker',
     name: 'file',
     label: 'Start date',
-    date: new Date('10 Feb 2020 00:00:00 GMT'),
+    date: '2020-02-10',
     onChange: () => 1,
 }
 

--- a/src/components/DatePicker/DatePickerField.js
+++ b/src/components/DatePicker/DatePickerField.js
@@ -31,10 +31,7 @@ const Wrapper = ({
 
 Wrapper.propTypes = {
     input: PropTypes.shape({
-        value: PropTypes.oneOfType([
-            PropTypes.instanceOf(Date),
-            PropTypes.string,
-        ]),
+        value: PropTypes.string,
         onChange: PropTypes.func,
     }).isRequired,
     inputName: PropTypes.string.isRequired,
@@ -45,17 +42,15 @@ Wrapper.propTypes = {
     }).isRequired,
 }
 
-const DatePickerField = ({ name, validator, ...rest }) => {
-    return (
-        <Field
-            component={Wrapper}
-            name={name}
-            validate={validator}
-            inputName={name}
-            {...rest}
-        />
-    )
-}
+const DatePickerField = ({ name, validator, ...rest }) => (
+    <Field
+        component={Wrapper}
+        name={name}
+        validate={validator}
+        inputName={name}
+        {...rest}
+    />
+)
 
 DatePickerField.propTypes = {
     name: PropTypes.string.isRequired,

--- a/src/pages/DataExport/DataExport.js
+++ b/src/pages/DataExport/DataExport.js
@@ -32,6 +32,7 @@ import {
     ExportButton,
     FormAlerts,
 } from '../../components/Inputs/index.js'
+import { jsDateToISO8601 } from '../../utils/helper.js'
 import { onExport, validate } from './form-helper.js'
 
 const { Form } = ReactFinalForm
@@ -44,18 +45,20 @@ export const PAGE_DESCRIPTION = i18n.t(
 const PAGE_ICON = <DataIcon />
 
 const today = new Date()
+const threeMonthsBeforeToday = new Date(
+    today.getFullYear(),
+    today.getMonth() - 3,
+    today.getDate()
+)
+
 const initialValues = {
     selectedOrgUnits: [],
     includeChildren: true,
     selectedDataSets: [],
     format: defaultFormatOption,
     compression: defaultCompressionOption,
-    startDate: new Date(
-        today.getFullYear(),
-        today.getMonth() - 3,
-        today.getDate()
-    ),
-    endDate: today,
+    startDate: jsDateToISO8601(threeMonthsBeforeToday),
+    endDate: jsDateToISO8601(today),
     includeDeleted: false,
     dataElementIdScheme: defaultDataElementIdSchemeOption,
     orgUnitIdScheme: defaultOrgUnitIdSchemeOption,

--- a/src/pages/DataExport/form-helper.js
+++ b/src/pages/DataExport/form-helper.js
@@ -6,7 +6,6 @@ import {
     locationAssign,
     compressionToName,
     fileFormatToFileExtension,
-    jsDateToISO8601,
     pathToId,
 } from '../../utils/helper.js'
 
@@ -32,8 +31,8 @@ const valuesToParams = (
         `idScheme=${idScheme}`,
         `includeDeleted=${includeDeleted}`,
         `children=${includeChildren}`,
-        `startDate=${jsDateToISO8601(startDate)}`,
-        `endDate=${jsDateToISO8601(endDate)}`,
+        `startDate=${startDate}`,
+        `endDate=${endDate}`,
         `orgUnit=${selectedOrgUnits.map((o) => pathToId(o))}`,
         `dataSet=${selectedDataSets}`,
         `format=${encodeURIComponent(format)}`,

--- a/src/pages/EventExport/EventExport.js
+++ b/src/pages/EventExport/EventExport.js
@@ -33,6 +33,7 @@ import {
     IdScheme,
     defaultIdSchemeOption,
 } from '../../components/Inputs/index.js'
+import { jsDateToISO8601 } from '../../utils/helper.js'
 import { onExport, validate } from './form-helper.js'
 
 const { Form } = ReactFinalForm
@@ -45,18 +46,20 @@ export const PAGE_DESCRIPTION = i18n.t(
 const PAGE_ICON = <EventIcon />
 
 const today = new Date()
+const threeMonthsBeforeToday = new Date(
+    today.getFullYear(),
+    today.getMonth() - 3,
+    today.getDate()
+)
+
 const initialValues = {
     selectedOrgUnits: [],
     selectedPrograms: '',
     programStage: undefined,
     format: defaultFormatOption,
     compression: defaultCompressionOption,
-    startDate: new Date(
-        today.getFullYear(),
-        today.getMonth() - 3,
-        today.getDate()
-    ),
-    endDate: today,
+    startDate: jsDateToISO8601(threeMonthsBeforeToday),
+    endDate: jsDateToISO8601(today),
     includeDeleted: false,
     dataElementIdScheme: defaultDataElementIdSchemeOption,
     orgUnitIdScheme: defaultOrgUnitIdSchemeOption,

--- a/src/pages/EventExport/form-helper.js
+++ b/src/pages/EventExport/form-helper.js
@@ -3,11 +3,7 @@ import {
     DATE_AFTER_VALIDATOR,
 } from '../../components/DatePicker/DatePickerField.js'
 import { ALL_VALUE } from '../../hooks/useProgramStages.js'
-import {
-    jsDateToISO8601,
-    locationAssign,
-    pathToId,
-} from '../../utils/helper.js'
+import { locationAssign, pathToId } from '../../utils/helper.js'
 
 const onExport = (baseUrl, setExportEnabled) => (values) => {
     setExportEnabled(false)
@@ -42,8 +38,8 @@ const onExport = (baseUrl, setExportEnabled) => (values) => {
         `orgUnitIdScheme=${orgUnitIdScheme}`,
         `idScheme=${idScheme}`,
         `attachment=${filename}`,
-        `startDate=${jsDateToISO8601(startDate)}`,
-        `endDate=${jsDateToISO8601(endDate)}`,
+        `startDate=${startDate}`,
+        `endDate=${endDate}`,
         `ouMode=${inclusion}`,
         `format=${format}`,
         programStage != ALL_VALUE ? `programStage=${programStage}` : '',

--- a/src/pages/TEIExport/form-helper.js
+++ b/src/pages/TEIExport/form-helper.js
@@ -4,11 +4,7 @@ import {
     DATE_AFTER_VALIDATOR,
 } from '../../components/DatePicker/DatePickerField.js'
 import { OU_MODE_MANUAL_VALUE } from '../../components/Inputs/index.js'
-import {
-    locationAssign,
-    jsDateToISO8601,
-    pathToId,
-} from '../../utils/helper.js'
+import { locationAssign, pathToId } from '../../utils/helper.js'
 
 // calculate minimum set of parameters based on given filters
 const valuesToParams = (
@@ -78,11 +74,11 @@ const valuesToParams = (
         minParams.followUpStatus = followUpStatus
 
         if (programStartDate) {
-            minParams.programStartDate = jsDateToISO8601(programStartDate)
+            minParams.programStartDate = programStartDate
         }
 
         if (programEndDate) {
-            minParams.programEndDate = jsDateToISO8601(programEndDate)
+            minParams.programEndDate = programEndDate
         }
     }
 
@@ -92,12 +88,11 @@ const valuesToParams = (
 
     if (lastUpdatedFilter == 'DATE') {
         if (lastUpdatedStartDate) {
-            minParams.lastUpdatedStartDate =
-                jsDateToISO8601(lastUpdatedStartDate)
+            minParams.lastUpdatedStartDate = lastUpdatedStartDate
         }
 
         if (lastUpdatedEndDate) {
-            minParams.lastUpdatedEndDate = jsDateToISO8601(lastUpdatedEndDate)
+            minParams.lastUpdatedEndDate = lastUpdatedEndDate
         }
     }
 


### PR DESCRIPTION
This fixes an issue with the DatePicker where if you are in a time zone earlier than UTC, the date you selected would be the previous day's date (i.e. I would try to select "2023-06-09" and I would get "2023-06-08"). See [DHIS2-12489](https://dhis2.atlassian.net/jira/software/c/projects/DHIS2/issues/DHIS2-12489).

Note: I guess we could update to our own calendar inputs and also fix the issue that way, but it seems maybe worth it to fix the bug first?

We have this bug because:

- we ultimately use a native <input type='date' />  element for our the date selector, which will store the selected date as a `yyyy-mm-dd` string (if it's implemented by the browser: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/date)

- on change, we were converting the string value to a javascript date (and then back again) (https://github.com/dhis2/import-export-app/blob/master/src/components/DatePicker/DatePicker.js#L11-L15). Unfortunately, when you initialize a date from a `yyyy-mm-dd` string, it assumes* that the date is `yyyy-mm-ddT00:00...Z` (i.e. midnight UTC), and since javascript dates only reflect your client timezone, this would be "converted" to the previous day if you're in a time zone before UTC (e.g. if I'm in New York, it assumed I had selected "2023-06-09 midnight UTC", which would be "2023-06-08 20:00" for me)

*this is theoretically browser-dependent, but this is how it behaves in any browser I've seen

I'm not really sure why we were doing this conversion 🤔. We did have some initial values that were being passed as date objects, but it's also possible to pass them as strings, so we shouldn't need to convert back and forth.

**Current**
![current-date-selector](https://github.com/dhis2/import-export-app/assets/18490902/dedadf1b-99de-4647-b705-80318ec4987f)


**After**
![fixed-date-selector](https://github.com/dhis2/import-export-app/assets/18490902/7e190ec9-8143-41ad-9339-283da565ccd7)


[DHIS2-12489]: https://dhis2.atlassian.net/browse/DHIS2-12489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ