### PR TITLE
fix: avoid breaking selects [DHIS2-16264]

### DIFF
--- a/src/components/ElementSchemes/DataElementIdScheme.js
+++ b/src/components/ElementSchemes/DataElementIdScheme.js
@@ -22,7 +22,7 @@ const DataElementIdScheme = ({
         fetchAttributes(`${baseUrl}/api/`, 'dataElementAttribute')
             .then((attributes) => setSchemes(attributes))
             .catch((error) => setError(error))
-        setLoading(false)
+            .finally(() => setLoading(false))
     }, [])
 
     const validationText =

--- a/src/components/ElementSchemes/OrgUnitIdScheme.js
+++ b/src/components/ElementSchemes/OrgUnitIdScheme.js
@@ -17,7 +17,7 @@ const OrgUnitIdScheme = ({ name, label, orgUnitIdSchemeOptions, dataTest }) => {
         fetchAttributes(`${baseUrl}/api/`, 'organisationUnitAttribute')
             .then((attributes) => setSchemes(attributes))
             .catch((error) => setError(error))
-        setLoading(false)
+            .finally(() => setLoading(false))
     }, [])
 
     const validationText =

--- a/src/components/MoreOptions/MoreOptions.js
+++ b/src/components/MoreOptions/MoreOptions.js
@@ -48,7 +48,10 @@ const MoreOptions = ({
                 <h2 className={styles.label}>{label}</h2>
             </header>
             {!hidden && <Divider />}
-            <div className={cx(styles.children, { [styles.hidden]: hidden })} data-test={`${dataTest}-children`}>
+            <div
+                className={cx(styles.children, { [styles.hidden]: hidden })}
+                data-test={`${dataTest}-children`}
+            >
                 {hasOpened && children}
             </div>
         </section>

--- a/src/components/MoreOptions/MoreOptions.js
+++ b/src/components/MoreOptions/MoreOptions.js
@@ -5,6 +5,11 @@ import PropTypes from 'prop-types'
 import React, { useState } from 'react'
 import styles from './MoreOptions.module.css'
 
+/**
+ * If not initially visible, doesn't render children. After opening the first
+ * time, however, children are instead hidden by CSS on toggle to preserve
+ * state
+ */
 const MoreOptions = ({
     children,
     initiallyVisible,
@@ -13,8 +18,12 @@ const MoreOptions = ({
     dataTest = 'interaction-more-options',
 }) => {
     const [hidden, setHidden] = useState(!initiallyVisible)
+    const [hasOpened, setHasOpened] = useState(initiallyVisible)
 
     const onToggle = () => {
+        if (!hasOpened) {
+            setHasOpened(true)
+        }
         setHidden(!hidden)
     }
 
@@ -39,8 +48,8 @@ const MoreOptions = ({
                 <h2 className={styles.label}>{label}</h2>
             </header>
             {!hidden && <Divider />}
-            <div className={styles.children} data-test={`${dataTest}-children`}>
-                {!hidden && children}
+            <div className={cx(styles.children, { [styles.hidden]: hidden })} data-test={`${dataTest}-children`}>
+                {hasOpened && children}
             </div>
         </section>
     )

--- a/src/components/MoreOptions/MoreOptions.module.css
+++ b/src/components/MoreOptions/MoreOptions.module.css
@@ -29,6 +29,10 @@
     margin-top: var(--spacers-dp4);
 }
 
+.hidden {
+    display: none;
+}
+
 .chevronHidden svg {
     transform: rotate(90deg);
 }

--- a/src/components/MoreOptions/__snapshots__/MoreOptions.test.js.snap
+++ b/src/components/MoreOptions/__snapshots__/MoreOptions.test.js.snap
@@ -32,7 +32,7 @@ exports[`matches snapshot when not toggled 1`] = `
       </h2>
     </header>
     <div
-      class="children"
+      class="children hidden"
       data-test="more-options-children"
     />
   </section>

--- a/src/components/Page/__snapshots__/Page.test.js.snap
+++ b/src/components/Page/__snapshots__/Page.test.js.snap
@@ -563,7 +563,7 @@ exports[`matches snapshot when not loading and a mini summary task 1`] = `
             </h2>
           </header>
           <div
-            class="children"
+            class="children hidden"
             data-test="mini-job-summary-container-MoreOptions-children"
           />
         </section>


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-16264

The select components do a fetch on render for attributes to populate some options (the top two or three are hard-coded though). If you select an option that was populated by the fetch, that value is saved in the Final Form state. If you collapse the Advanced Options section, then re-expand the section, the select tries to choose the option based on that value, _but_ the component needs to fetch again, so that option isn't available on first render

**Edited:**
I changed the `<MoreOptions>` component to keep children rendered to preserve state, and then hide them with CSS

Before:

https://github.com/dhis2/import-export-app/assets/49666798/6af20755-1c1d-4069-98f7-7ada89b0b83b


After:

https://github.com/dhis2/import-export-app/assets/49666798/503004b9-85a9-417b-8041-3ef4bac0f98f



