### PR TITLE
chore: move app to continuous release

### DIFF
--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -150,42 +150,25 @@ jobs:
     #                  SERVER_START_CMD: 'yarn start'
     #                  SERVER_URL: 'http://localhost:3000'
 
-    publish:
-        runs-on: ubuntu-latest
-        needs: [build, lint, test] # add e2e if you use it
-        if: "!contains(github.event.head_commit.message, '[skip ci]')"
-        steps:
-            - uses: actions/checkout@v2
-              with:
-                  token: ${{env.GH_TOKEN}}
-
-            - uses: actions/setup-node@v1
-              with:
-                  node-version: 16.x
-
-            - uses: actions/download-artifact@v2
-              with:
-                  name: app-build
-
-            - uses: dhis2/deploy-build@master
-              with:
-                  # uncomment following line for monorepo apps:
-                  #cwd: ./packages/app
-                  build-dir: build/app
-                  github-token: ${{ env.GH_TOKEN }}
-
     release:
         runs-on: ubuntu-latest
-        needs: [publish]
+        needs: [build, lint, test]
         if: "github.event_name == 'push' && !contains(github.event.head_commit.message, '[skip ci]')"
         steps:
             - uses: actions/checkout@v2
               with:
                   token: ${{env.GH_TOKEN}}
 
-            - uses: actions/setup-node@v1
+            - uses: dhis2/action-semantic-release@master
               with:
-                  node-version: 16.x
+                  publish-apphub: true
+                  publish-github: true
+                  github-token: ${{ secrets.DHIS2_BOT_GITHUB_TOKEN }}
+                  apphub-token: ${{ secrets.DHIS2_BOT_APPHUB_TOKEN }}
 
-            - name: Publish release to GitHub
-              run: npx @dhis2/cli-utils release
+            - uses: dhis2/deploy-build@master
+              with:
+                  # uncomment following line for monorepo apps:
+                  #cwd: ./packages/app
+                  build-dir: build/app
+                  github-token: ${{ secrets.DHIS2_BOT_GITHUB_TOKEN }}

--- a/d2.config.js
+++ b/d2.config.js
@@ -1,9 +1,11 @@
 const config = {
+    id: '275afdce-16d2-40e1-8a9b-5b22d882ed74',
     type: 'app',
     name: 'import-export',
     title: 'Import/Export',
+    description: 'Core app for importing and exporting data to and from DHIS2.',
     coreApp: true,
-
+    minDHIS2Version: '2.41',
     entryPoints: {
         app: './src/App.js',
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "import-export-app",
-    "version": "1.5.69",
+    "version": "99.9.9",
     "description": "",
     "license": "BSD-3-Clause",
     "private": true,


### PR DESCRIPTION
moving import/export app to continous release from v41. I didn't apply to earlier versions since it seems that a lot has changed between versions (geo import, and other stuff) so it's hard to tell what applies to all versions or not.