### PR TITLE
fix(DHIS2-16526): remove merge mode from metadata import UI

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2024-02-12T17:08:02.188Z\n"
-"PO-Revision-Date: 2024-02-12T17:08:02.189Z\n"
+"POT-Creation-Date: 2024-03-01T15:50:32.586Z\n"
+"PO-Revision-Date: 2024-03-01T15:50:32.586Z\n"
 
 msgid "Something went wrong when loading the current user!"
 msgstr "Something went wrong when loading the current user!"
@@ -693,6 +693,12 @@ msgstr "Indexes"
 
 msgid "Details by type"
 msgstr "Details by type"
+
+msgid "All existing property values will be replaced"
+msgstr "All existing property values will be replaced"
+
+msgid "Values will be overwritten, even if the new value is null"
+msgstr "Values will be overwritten, even if the new value is null"
 
 msgid "Advanced options"
 msgstr "Advanced options"

--- a/src/components/MergeOperation/MergeOperation.js
+++ b/src/components/MergeOperation/MergeOperation.js
@@ -1,0 +1,27 @@
+import i18n from '@dhis2/d2-i18n'
+import { NoticeBox } from '@dhis2/ui'
+import React from 'react'
+
+const mergeOperation = 'REPLACE'
+
+const MERGE_NOTICE_TITLE = i18n.t(
+    'All existing property values will be replaced'
+)
+const MERGE_NOTICE_TEXT = i18n.t(
+    'Values will be overwritten, even if the new value is null'
+)
+
+const MergeOperationNotice = () => {
+    return (
+        <div style={{ maxWidth: '80%' }}>
+            <NoticeBox
+                dataTest={'merge-operation-notice'}
+                title={MERGE_NOTICE_TITLE}
+            >
+                {MERGE_NOTICE_TEXT}
+            </NoticeBox>
+        </div>
+    )
+}
+
+export { mergeOperation, MergeOperationNotice }

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -48,3 +48,7 @@ export { SchemeContainer } from './ElementSchemes/SchemeContainer.js'
 export { StyledField } from './StyledField/StyledField.js'
 export { Tooltip } from './Tooltip/Tooltip.js'
 export { ValidationSummary } from './ValidationSummary/ValidationSummary.js'
+export {
+    mergeOperation,
+    MergeOperationNotice,
+} from './MergeOperation/MergeOperation.js'

--- a/src/pages/MetadataImport/MetadataImport.js
+++ b/src/pages/MetadataImport/MetadataImport.js
@@ -9,6 +9,8 @@ import {
     MoreOptions,
     BasicOptions,
     ValidationSummary,
+    mergeOperation,
+    MergeOperationNotice,
 } from '../../components/index.js'
 import {
     FileUpload,
@@ -26,8 +28,6 @@ import {
     defaultImportStrategyOption,
     AtomicMode,
     defaultAtomicModeOption,
-    MergeMode,
-    defaultMergeModeOption,
     FlushMode,
     defaultFlushModeOption,
     SkipSharing,
@@ -67,7 +67,7 @@ const createInitialValues = (prevJobDetails) => ({
         defaultFirstRowIsHeaderOption
     ),
     atomicMode: prevJobDetails.atomicMode || defaultAtomicModeOption,
-    mergeMode: prevJobDetails.mergeMode || defaultMergeModeOption,
+    mergeMode: prevJobDetails.mergeMode || mergeOperation,
     flushMode: prevJobDetails.flushMode || defaultFlushModeOption,
     inclusionStrategy:
         prevJobDetails.inclusionStrategy || defaultInclusionStrategyOption,
@@ -146,7 +146,7 @@ const MetadataImport = () => {
                             <ImportReportMode />
                             <ImportStrategy value={values.importStrategy} />
                             <AtomicMode />
-                            <MergeMode />
+                            <MergeOperationNotice />
                         </BasicOptions>
                         <MoreOptions>
                             <FlushMode />


### PR DESCRIPTION
Implements [DHIS2-16526](https://dhis2.atlassian.net/browse/DHIS2-16526)

------------------------

**Description**

This PR removes the Merge Mode options from the MetaData Import UI, i.e. choosing between `Merge` and `Replace`. It adds functionality to ensure that the merge option is always 'REPLACE'. It also notifies the user of this operation. 

------------------------

**Tasks**
- [x] Removed the `MergeMode` radio group options from the MetaData Import UI
- [x]  Added a `MergeOperationNotice` Component that tells the user all existing values will be replaced by new values.
- [x]  The only value passed to the `mergeMode` URL parameter is `REPLACE`. 

------------------------

**Screenshots**
- Before:
<img width="1136" alt="before - merge mode" src="https://github.com/dhis2/import-export-app/assets/31903212/3450bce0-a4db-4b41-a01c-3e568d397bd1">

- After:
<img width="1124" alt="after - merge notice" src="https://github.com/dhis2/import-export-app/assets/31903212/b76b71ad-a0f7-4ea9-b152-59f5d75c43fb">


[DHIS2-16526]: https://dhis2.atlassian.net/browse/DHIS2-16526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ