### PR TITLE
fix: remove merge mode from metadata import UI

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2023-03-06T13:48:45.764Z\n"
-"PO-Revision-Date: 2023-03-06T13:48:45.764Z\n"
+"POT-Creation-Date: 2024-03-01T15:50:32.586Z\n"
+"PO-Revision-Date: 2024-03-01T15:50:32.586Z\n"
 
 msgid "Something went wrong when loading the current user!"
 msgstr "Something went wrong when loading the current user!"
@@ -693,6 +693,12 @@ msgstr "Indexes"
 
 msgid "Details by type"
 msgstr "Details by type"
+
+msgid "All existing property values will be replaced"
+msgstr "All existing property values will be replaced"
+
+msgid "Values will be overwritten, even if the new value is null"
+msgstr "Values will be overwritten, even if the new value is null"
 
 msgid "Advanced options"
 msgstr "Advanced options"

--- a/src/components/MergeOperation/MergeOperation.js
+++ b/src/components/MergeOperation/MergeOperation.js
@@ -1,0 +1,27 @@
+import i18n from '@dhis2/d2-i18n'
+import { NoticeBox } from '@dhis2/ui'
+import React from 'react'
+
+const mergeOperation = 'REPLACE'
+
+const MERGE_NOTICE_TITLE = i18n.t(
+    'All existing property values will be replaced'
+)
+const MERGE_NOTICE_TEXT = i18n.t(
+    'Values will be overwritten, even if the new value is null'
+)
+
+const MergeOperationNotice = () => {
+    return (
+        <div style={{ maxWidth: '80%' }}>
+            <NoticeBox
+                dataTest={'merge-operation-notice'}
+                title={MERGE_NOTICE_TITLE}
+            >
+                {MERGE_NOTICE_TEXT}
+            </NoticeBox>
+        </div>
+    )
+}
+
+export { mergeOperation, MergeOperationNotice }

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -48,3 +48,7 @@ export { SchemeContainer } from './ElementSchemes/SchemeContainer.js'
 export { StyledField } from './StyledField/StyledField.js'
 export { Tooltip } from './Tooltip/Tooltip.js'
 export { ValidationSummary } from './ValidationSummary/ValidationSummary.js'
+export {
+    mergeOperation,
+    MergeOperationNotice,
+} from './MergeOperation/MergeOperation.js'

--- a/src/pages/MetadataImport/MetadataImport.js
+++ b/src/pages/MetadataImport/MetadataImport.js
@@ -9,6 +9,8 @@ import {
     MoreOptions,
     BasicOptions,
     ValidationSummary,
+    mergeOperation,
+    MergeOperationNotice,
 } from '../../components/index.js'
 import {
     FileUpload,
@@ -26,8 +28,6 @@ import {
     defaultImportStrategyOption,
     AtomicMode,
     defaultAtomicModeOption,
-    MergeMode,
-    defaultMergeModeOption,
     FlushMode,
     defaultFlushModeOption,
     SkipSharing,
@@ -67,7 +67,7 @@ const createInitialValues = (prevJobDetails) => ({
         defaultFirstRowIsHeaderOption
     ),
     atomicMode: prevJobDetails.atomicMode || defaultAtomicModeOption,
-    mergeMode: prevJobDetails.mergeMode || defaultMergeModeOption,
+    mergeMode: prevJobDetails.mergeMode || mergeOperation,
     flushMode: prevJobDetails.flushMode || defaultFlushModeOption,
     inclusionStrategy:
         prevJobDetails.inclusionStrategy || defaultInclusionStrategyOption,
@@ -146,7 +146,7 @@ const MetadataImport = () => {
                             <ImportReportMode />
                             <ImportStrategy value={values.importStrategy} />
                             <AtomicMode />
-                            <MergeMode />
+                            <MergeOperationNotice />
                         </BasicOptions>
                         <MoreOptions>
                             <FlushMode />


### PR DESCRIPTION
**Description**
This PR removes the merge mode from the metadata import UI for v39 of the import-export app. 

**Reference issue** 
[DHIS2-16526](https://dhis2.atlassian.net/browse/DHIS2-16526)

**Related PR**
https://github.com/dhis2/import-export-app/pull/1986


[DHIS2-16526]: https://dhis2.atlassian.net/browse/DHIS2-16526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ