### PR TITLE
fix: update wrong parameters for tracker api migration

### DIFF
--- a/src/components/Inputs/FollowUpStatus.js
+++ b/src/components/Inputs/FollowUpStatus.js
@@ -10,7 +10,7 @@ const followUpStatusOptions = [
 ]
 const defaultFollowUpStatusOption = followUpStatusOptions[0].value
 
-const NAME = 'followup'
+const NAME = 'followUp'
 const DATATEST = 'input-follow-up-status'
 const LABEL = i18n.t('Include only entities with follow-up status')
 

--- a/src/pages/EventExport/EventExport.js
+++ b/src/pages/EventExport/EventExport.js
@@ -65,7 +65,8 @@ const initialValues = {
     orgUnitIdScheme: defaultOrgUnitIdSchemeOption,
     idScheme: defaultIdSchemeOption,
     inclusion: defaultInclusionOption,
-    skipPaging: true,
+    paging: false,
+    totalPages: false
 }
 
 const EventExport = () => {

--- a/src/pages/EventExport/EventExport.js
+++ b/src/pages/EventExport/EventExport.js
@@ -66,7 +66,7 @@ const initialValues = {
     idScheme: defaultIdSchemeOption,
     inclusion: defaultInclusionOption,
     paging: false,
-    totalPages: false
+    totalPages: false,
 }
 
 const EventExport = () => {

--- a/src/pages/EventExport/form-helper.js
+++ b/src/pages/EventExport/form-helper.js
@@ -30,7 +30,8 @@ const onExport = (baseUrl, setExportEnabled) => (values) => {
     const filename = `${endpoint}.${endpointExtension}`
     const downloadUrlParams = [
         'links=false',
-        'skipPaging=true',
+        'paging=false',
+        'totalPages=false',
         `orgUnit=${pathToId(selectedOrgUnits[0])}`,
         `program=${selectedPrograms}`,
         `includeDeleted=${includeDeleted}`,

--- a/src/pages/TEIExport/TEIExport.js
+++ b/src/pages/TEIExport/TEIExport.js
@@ -68,7 +68,7 @@ const initialValues = {
     inclusion: defaultInclusionOption,
     teiTypeFilter: defaultTEITypeFilterOption,
     programStatus: defaultProgramStatusOption,
-    followup: defaultFollowUpStatusOption,
+    followUp: defaultFollowUpStatusOption,
     enrollmentEnrolledAfter: '',
     enrollmentEnrolledBefore: '',
     compression: '', // disable compression until it is properly implemented in the backend

--- a/src/pages/TEIExport/form-helper.js
+++ b/src/pages/TEIExport/form-helper.js
@@ -44,7 +44,8 @@ const valuesToParams = (
         orgUnitIdScheme: orgUnitIdScheme,
         idScheme: idScheme,
         attachment: filename,
-        skipPaging: true,
+        paging: false,
+        totalPages: false
     }
 
     // include selected org.units only when manual selection is selected

--- a/src/pages/TEIExport/form-helper.js
+++ b/src/pages/TEIExport/form-helper.js
@@ -25,7 +25,7 @@ const valuesToParams = (
         assignedUserMode,
         teiTypeFilter,
         programStatus,
-        followup,
+        followUp,
         enrollmentEnrolledAfter,
         enrollmentEnrolledBefore,
         lastUpdatedFilter,
@@ -70,8 +70,8 @@ const valuesToParams = (
             minParams.programStatus = programStatus
         }
 
-        if (followup !== 'ALL') {
-            minParams.followup = followup
+        if (followUp !== 'ALL') {
+            minParams.followUp = followUp
         }
 
         if (enrollmentEnrolledAfter) {

--- a/src/pages/TEIExport/form-helper.js
+++ b/src/pages/TEIExport/form-helper.js
@@ -45,13 +45,13 @@ const valuesToParams = (
         idScheme: idScheme,
         attachment: filename,
         paging: false,
-        totalPages: false
+        totalPages: false,
     }
 
     // include selected org.units only when manual selection is selected
     // ouMode is then stored in the `inclusion` field
     if (ouMode === OU_MODE_MANUAL_VALUE) {
-        minParams.orgUnit = selectedOrgUnits.map((o) => pathToId(o)).join(';')
+        minParams.orgUnits = selectedOrgUnits.map((o) => pathToId(o)).join(',')
         minParams.ouMode = inclusion
     }
 
@@ -59,7 +59,7 @@ const valuesToParams = (
         minParams.assignedUserMode = assignedUserMode
 
         if (assignedUserMode == 'PROVIDED') {
-            minParams.assignedUser = selectedUsers.join(';')
+            minParams.assignedUsers = selectedUsers.join(',')
         }
     }
 


### PR DESCRIPTION
This updates wrong parameters sent to the tracker API after feedback from the backend team:

- update the casing for `followup` params to `followUp`
- remove `skipPaging` param and use `paging=false` instead
- change the separator for arrays from [a semicolon to a comma](https://github.com/dhis2/dhis2-releases/blob/master/releases/2.41/README.md#semicolon-as-separator-for-identifiers-uid)

Relates to https://dhis2.atlassian.net/browse/DHIS2-16133