### PR TITLE
fix(tracker-api-migration): fix 'created' value not displaying in the job summary

### DIFF
--- a/src/components/JobSummary/SingleSummary/SingleSummary.js
+++ b/src/components/JobSummary/SingleSummary/SingleSummary.js
@@ -49,7 +49,9 @@ const SingleSummary = ({
                     <TableBody>
                         <TableRow>
                             <TableCell>
-                                {importCount?.imported ?? '0'}
+                                {importCount?.imported ??
+                                    importCount?.created ??
+                                    '0'}
                             </TableCell>
                             <TableCell>{importCount?.deleted}</TableCell>
                             <TableCell>{importCount?.ignored}</TableCell>

--- a/src/components/JobSummary/Summary/Summary.js
+++ b/src/components/JobSummary/Summary/Summary.js
@@ -14,8 +14,7 @@ const extractStats = (summary) => {
         const total = imported + deleted + ignored + updated
         return { imported, deleted, ignored, updated, total }
     } else if (summary.stats) {
-        const { imported, deleted, ignored, updated, total } = summary.stats
-        return { imported, deleted, ignored, updated, total }
+        return summary.stats
     }
 }
 


### PR DESCRIPTION
fixes [DHIS2-16133](https://dhis2.atlassian.net/browse/DHIS2-17046) - the "created" property was renamed from "imported" to "created". The UI was picking up the old property hence not displaying a value when there is one.

[DHIS2-16133]: https://dhis2.atlassian.net/browse/DHIS2-16133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ