### PR TITLE
feat: update the summary table to display a message

### DIFF
--- a/src/components/JobSummary/JobSummary.js
+++ b/src/components/JobSummary/JobSummary.js
@@ -82,7 +82,11 @@ const JobSummary = ({
             <Tags jobDetails={jobDetails} task={task} />
             <Divider />
             {task.completed && task.summary && (
-                <Summary summary={task.summary} importType={task.importType} />
+                <Summary
+                    summary={task.summary}
+                    importType={task.importType}
+                    isDryRun={jobDetails.dryRun}
+                />
             )}
             <div className={styles.events}>
                 <Log events={task.events} />

--- a/src/components/JobSummary/Summary/Summary.js
+++ b/src/components/JobSummary/Summary/Summary.js
@@ -1,3 +1,5 @@
+import i18n from '@dhis2/d2-i18n'
+import { NoticeBox } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React from 'react'
 import { typeReportParse } from '../helper.js'
@@ -6,7 +8,7 @@ import { TypeReportSummary } from '../TypeReportSummary/TypeReportSummary.js'
 import styles from './Summary.module.css'
 
 const extractStats = (summary) => {
-    if (summary.responseType == 'ImportSummaries') {
+    if (summary.responseType === 'ImportSummaries') {
         const { imported, deleted, ignored, updated, total } = summary
         return { imported, deleted, ignored, updated, total }
     } else if (summary.importCount) {
@@ -18,8 +20,25 @@ const extractStats = (summary) => {
     }
 }
 
-const Summary = ({ summary, importType }) => {
-    // gml import type object return
+const Summary = ({ summary, importType, isDryRun }) => {
+    if (isDryRun && importType === 'TRACKER_IMPORT_JOB') {
+        const { ignored, total } = extractStats(summary)
+        return (
+            <div data-test="job-summary-summary" className={styles.container}>
+                <div
+                    className={styles.rest}
+                    data-test="job-summary-summary-rest"
+                >
+                    <NoticeBox title="Summary">
+                        {i18n.t(
+                            `${ignored} entities will be ignored out of ${total} entities⁠`
+                        )}
+                    </NoticeBox>
+                </div>
+            </div>
+        )
+    }
+
     if (summary.typeReports) {
         const overviewStats = {
             ...summary.stats,
@@ -56,8 +75,9 @@ const Summary = ({ summary, importType }) => {
             }
         />
     )
+
     const allSummaries =
-        summary.responseType == 'ImportSummaries' && summary.importSummaries
+        summary.responseType === 'ImportSummaries' && summary.importSummaries
             ? summary.importSummaries.map((s, i) => {
                   const importCount = extractStats(s)
                   return (
@@ -87,6 +107,7 @@ const Summary = ({ summary, importType }) => {
 Summary.propTypes = {
     summary: PropTypes.object.isRequired,
     importType: PropTypes.string,
+    isDryRun: PropTypes.bool,
 }
 
 export { Summary }


### PR DESCRIPTION
Implements [DHIS2-17164](https://dhis2.atlassian.net/browse/DHIS2-17164)
---

### Description
In the case of a dry run, this commit updates the table summary (screenshots below), and instead show a Notification that says "{ignoredCount} entities will be ignored out of {totalCount} entities"

---

### Known issues

-   [ ] None

---

### Checklist

-   [ ] API docs are generated
-   [ ] Tests were added
-   [ ] Storybook demos were added

_All points above should be relevant for feature PRs. For bugfixes, some points might not be relevant. In that case, just check them anyway to signal the work is done._

---

### Screenshots
<img width="1440" alt="Screenshot 2024-03-28 at 11 53 27" src="https://github.com/dhis2/import-export-app/assets/87203527/d1bc9175-781f-4483-a0ec-10b7c4c4a9de">

<img width="1440" alt="Screenshot 2024-03-28 at 15 28 56" src="https://github.com/dhis2/import-export-app/assets/87203527/07779a20-b17a-41ba-ad1b-09bed653785d">




[DHIS2-17164]: https://dhis2.atlassian.net/browse/DHIS2-17164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ