### PR TITLE
fix(geojson-import): only run validator when the use geometry option is selected

### DIFF
--- a/src/components/Geometry/GeometryAttributePicker.js
+++ b/src/components/Geometry/GeometryAttributePicker.js
@@ -27,6 +27,9 @@ const VALIDATOR = (selectedAttributes = []) =>
         ? i18n.t('One attribute must be selected')
         : undefined
 
+const getValidator = (useAttribute) =>
+    useAttribute ? VALIDATOR : Function.prototype
+
 const HELPTEXT = i18n.t(
     'Associated geometry import requires an attribute of type "GeoJSON" applied to "Organisation unit". It can be defined in the Maintenance app.'
 )
@@ -66,7 +69,7 @@ const GeometryAttributePicker = ({
                     selectedLabel={SELECTEDLABEL}
                     dataTest={DATATEST}
                     multiSelect={multiSelect}
-                    validator={VALIDATOR}
+                    validator={getValidator(useAttribute)}
                     autoSelectFirst
                     {...rest}
                 />

--- a/src/components/Geometry/GeometryAttributePicker.js
+++ b/src/components/Geometry/GeometryAttributePicker.js
@@ -27,9 +27,6 @@ const VALIDATOR = (selectedAttributes = []) =>
         ? i18n.t('One attribute must be selected')
         : undefined
 
-const getValidator = (useAttribute) =>
-    useAttribute ? VALIDATOR : Function.prototype
-
 const HELPTEXT = i18n.t(
     'Associated geometry import requires an attribute of type "GeoJSON" applied to "Organisation unit". It can be defined in the Maintenance app.'
 )
@@ -69,7 +66,7 @@ const GeometryAttributePicker = ({
                     selectedLabel={SELECTEDLABEL}
                     dataTest={DATATEST}
                     multiSelect={multiSelect}
-                    validator={getValidator(useAttribute)}
+                    validator={useAttribute ? VALIDATOR : Function.prototype}
                     autoSelectFirst
                     {...rest}
                 />


### PR DESCRIPTION
Fixes https://dhis2.atlassian.net/browse/DHIS2-17071

The code will check if the "Import as associated geometry" is checked. If so, then the validator for that will run. Otherwise, it will not run the validator
![image](https://github.com/dhis2/import-export-app/assets/6113918/591f366c-1ea5-4400-a48d-3860f9526374)
