### PR TITLE
fix(geojson-import): only run validator when the use geometry option is selected [v40]

### DIFF
--- a/src/components/Geometry/GeometryAttributePicker.js
+++ b/src/components/Geometry/GeometryAttributePicker.js
@@ -66,7 +66,7 @@ const GeometryAttributePicker = ({
                     selectedLabel={SELECTEDLABEL}
                     dataTest={DATATEST}
                     multiSelect={multiSelect}
-                    validator={VALIDATOR}
+                    validator={useAttribute ? VALIDATOR : Function.prototype}
                     autoSelectFirst
                     {...rest}
                 />


### PR DESCRIPTION
Fixes https://dhis2.atlassian.net/browse/DHIS2-17071

Backport of https://github.com/dhis2/import-export-app/pull/2003

The code will check if the "Import as associated geometry" is checked.
If so, then the validator for that will run. Otherwise, it will not run the validator
