### PR TITLE
fix: fix typeError that crashes app when job overview is clicked

### DIFF
--- a/src/components/JobOverview/helper.js
+++ b/src/components/JobOverview/helper.js
@@ -6,7 +6,7 @@ const categoryTypesObj = categoryTypes.reduce((acc, cur) => {
 }, {})
 
 const jobToPath = job => ({
-    pathname: `/import/${categoryTypesObj[job.importType].key}`,
+    pathname: `/import/${categoryTypesObj[job.importType]?.key}`,
     query: { id: job.id },
 })
 


### PR DESCRIPTION
Implements [DHIS2-17151](https://dhis2.atlassian.net/browse/DHIS2-17151)
---

### Description
Fix app crashing when Job summary is clicked while doing a Tracked entity Import as seen in this [link](https://www.loom.com/share/3ed7e03081bf49e0bc57e2477d032036?sid=c5c42ef0-b7bd-41ab-8f4d-c465c092e657) 

this is a backport from this [PR](https://github.com/dhis2/import-export-app/pull/2017)

---

### Known issues

-   [ ] None

---


[DHIS2-17151]: https://dhis2.atlassian.net/browse/DHIS2-17151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ