### PR TITLE
fix(DHIS2-16988): download uncompressed json rather than open inline

### DIFF
--- a/src/utils/helper.js
+++ b/src/utils/helper.js
@@ -188,22 +188,32 @@ const uploadFile = ({
     })
 }
 
-const downloadWindowTitle = i18n.t('Loading exported data')
-const downloadWindowHtml = `
-<div style="height: 100%; width: 100%; display: flex; justify-content: center; align-items: center; color: rgb(33, 41, 52)">
-    <p>${downloadWindowTitle}</p>
-</div>
-`
-
 // call stub function if available
-const locationAssign = (url) => {
+const locationAssign = (relativeUrl) => {
     if (window.locationAssign) {
-        window.locationAssign(url)
+        window.locationAssign(relativeUrl)
     } else {
-        const downloadWindow = window.open(url, '_blank')
+        try {
+            const url = relativeUrl.startsWith('..')
+                ? new URL(relativeUrl, document.baseURI).href
+                : relativeUrl
 
-        downloadWindow.document.title = downloadWindowTitle
-        downloadWindow.document.body.innerHTML = downloadWindowHtml // does not work in Chrome
+            const urlFilePart = new URL(url).pathname.split('/').pop()
+            const [, file, extension] = urlFilePart.match(/(^[^.]+)(\..+$)/)
+
+            const downloadedFileName = `${file}${extension}`
+
+            const link = document.createElement('a')
+            link.href = url
+            link.download = downloadedFileName
+            link.target = '_blank'
+            link.click()
+
+            return link
+        } catch (err) {
+            console.error(err)
+            window.open(relativeUrl, '_blank')
+        }
     }
 }
 

--- a/src/utils/helper.js
+++ b/src/utils/helper.js
@@ -189,30 +189,28 @@ const uploadFile = ({
 }
 
 // call stub function if available
-const locationAssign = (relativeUrl) => {
+const locationAssign = (url) => {
     if (window.locationAssign) {
-        window.locationAssign(relativeUrl)
+        window.locationAssign(url)
     } else {
         try {
-            const url = relativeUrl.startsWith('..')
-                ? new URL(relativeUrl, document.baseURI).href
-                : relativeUrl
+            const downloadUrl = url.startsWith('..')
+                ? new URL(url, document.baseURI).href
+                : url
 
-            const urlFilePart = new URL(url).pathname.split('/').pop()
-            const [, file, extension] = urlFilePart.match(/(^[^.]+)(\..+$)/)
-
-            const downloadedFileName = `${file}${extension}`
+            const urlFilePart = new URL(downloadUrl).pathname.split('/').pop()
+            const [, filename] = urlFilePart.match(/(^[^.]+)(\..+$)/)
 
             const link = document.createElement('a')
-            link.href = url
-            link.download = downloadedFileName
+            link.href = downloadUrl
+            link.download = filename
             link.target = '_blank'
             link.click()
 
             return link
         } catch (err) {
             console.error(err)
-            window.open(relativeUrl, '_blank')
+            window.open(url, '_blank')
         }
     }
 }

--- a/src/utils/helper.test.js
+++ b/src/utils/helper.test.js
@@ -1,0 +1,60 @@
+import { locationAssign } from './helper.js'
+
+describe('locationAssign', () => {
+    it('should create a file name based on the params', () => {
+        const url =
+            'https://debug.dhis2.org/dev/api/tracker/trackedEntities.json?ouMode=CAPTURE&format=json&includeDeleted=false&dataElementIdScheme=UID&eventIdScheme=UID&orgUnitIdScheme=UID&idScheme=UID&attachment=trackedEntities.json&paging=false&totalPages=false&program=lxAQ7Zs9VYR'
+        const link = locationAssign(url)
+        expect(link.download).toEqual('trackedEntities.json')
+    })
+    it('should create url with orgUnits', () => {
+        const url =
+            'https://debug.dhis2.org/dev/api/tracker/trackedEntities.json?ouMode=SELECTED&includeDeleted=false&dataElementIdScheme=UID&eventIdScheme=UID&orgUnitIdScheme=UID&idScheme=UID&attachment=trackedEntities.json&paging=false&totalPages=false&orgUnits=O6uvpzGd5pu,fdc6uOvgoji&program=kla3mAPgvCH'
+        const link = locationAssign(url)
+        expect(link.download).toEqual('trackedEntities.json')
+    })
+    it('should create url with tracked entities', () => {
+        const url =
+            'https://debug.dhis2.org/dev/api/tracker/trackedEntities.json?ouMode=SELECTED&includeDeleted=false&dataElementIdScheme=UID&eventIdScheme=UID&orgUnitIdScheme=UID&idScheme=UID&attachment=trackedEntities.json&paging=false&totalPages=false&orgUnits=ImspTQPwCqd&trackedEntityType=bVkFYAvoUCP'
+        const link = locationAssign(url)
+        expect(link.download).toEqual('trackedEntities.json')
+    })
+    it('should create url with CSV', () => {
+        const url =
+            'https://debug.dhis2.org/dev/api/tracker/trackedEntities.csv?ouMode=SELECTED&includeDeleted=false&dataElementIdScheme=UID&eventIdScheme=UID&orgUnitIdScheme=UID&idScheme=UID&attachment=trackedEntities.csv&paging=false&totalPages=false&orgUnits=ImspTQPwCqd&program=lxAQ7Zs9VYR'
+        const link = locationAssign(url)
+        expect(link.download).toEqual('trackedEntities.csv')
+    })
+
+    it('should create url with events zip', () => {
+        const url =
+            'https://debug.dhis2.org/dev/api/tracker/events.json.zip?links=false&paging=false&totalPages=false&orgUnit=fwH9ipvXde9&program=VBqh0ynB2wv&includeDeleted=false&dataElementIdScheme=UID&orgUnitIdScheme=UID&idScheme=UID&attachment=events.json.zip&occurredAfter=2023-12-12&occurredBefore=2024-03-12&ouMode=CHILDREN&format=json'
+        const link = locationAssign(url)
+        expect(link.download).toEqual('events.json.zip')
+    })
+
+    it('should create url with events gzip', () => {
+        const url =
+            'https://debug.dhis2.org/dev/api/tracker/events.json.gz?links=false&paging=false&totalPages=false&orgUnit=ImspTQPwCqd&program=lxAQ7Zs9VYR&includeDeleted=false&dataElementIdScheme=UID&orgUnitIdScheme=UID&idScheme=UID&attachment=events.json.gz&occurredAfter=2023-12-12&occurredBefore=2024-03-12&ouMode=SELECTED&format=json'
+        const link = locationAssign(url)
+        expect(link.download).toEqual('events.json.gz')
+    })
+    it('should work with relative URLs when bundled in DHIS2', () => {
+        Object.defineProperty(global.document, 'baseURI', {
+            value: 'http://localhost:8080/dhis-web-import-export/index.html#/export/tei',
+        })
+        const url =
+            '../api/tracker/trackedEntities.json?ouMode=SELECTED&includeDeleted=false&dataElementIdScheme=UID&eventIdScheme=UID&orgUnitIdScheme=UID&idScheme=UID&attachment=trackedEntities.json&paging=false&totalPages=false&orgUnits=ImspTQPwCqd&program=lxAQ7Zs9VYR'
+        const link = locationAssign(url)
+        expect(link.download).toEqual('trackedEntities.json')
+    })
+    it('should work with relative URLs when bundled in DHIS2 for zip', () => {
+        Object.defineProperty(global.document, 'baseURI', {
+            value: 'http://localhost:8080/dhis-web-import-export/index.html#/export/tei',
+        })
+        const url =
+            '../api/tracker/events.json.zip?links=false&paging=false&totalPages=false&orgUnit=ImspTQPwCqd&program=lxAQ7Zs9VYR&includeDeleted=false&dataElementIdScheme=UID&orgUnitIdScheme=UID&idScheme=UID&attachment=events.json.zip&occurredAfter=2023-12-12&occurredBefore=2024-03-12&ouMode=SELECTED&format=json'
+        const link = locationAssign(url)
+        expect(link.download).toEqual('events.json.zip')
+    })
+})

--- a/src/utils/helper.test.js
+++ b/src/utils/helper.test.js
@@ -5,39 +5,39 @@ describe('locationAssign', () => {
         const url =
             'https://debug.dhis2.org/dev/api/tracker/trackedEntities.json?ouMode=CAPTURE&format=json&includeDeleted=false&dataElementIdScheme=UID&eventIdScheme=UID&orgUnitIdScheme=UID&idScheme=UID&attachment=trackedEntities.json&paging=false&totalPages=false&program=lxAQ7Zs9VYR'
         const link = locationAssign(url)
-        expect(link.download).toEqual('trackedEntities.json')
+        expect(link.download).toEqual('trackedEntities')
     })
     it('should create url with orgUnits', () => {
         const url =
             'https://debug.dhis2.org/dev/api/tracker/trackedEntities.json?ouMode=SELECTED&includeDeleted=false&dataElementIdScheme=UID&eventIdScheme=UID&orgUnitIdScheme=UID&idScheme=UID&attachment=trackedEntities.json&paging=false&totalPages=false&orgUnits=O6uvpzGd5pu,fdc6uOvgoji&program=kla3mAPgvCH'
         const link = locationAssign(url)
-        expect(link.download).toEqual('trackedEntities.json')
+        expect(link.download).toEqual('trackedEntities')
     })
     it('should create url with tracked entities', () => {
         const url =
             'https://debug.dhis2.org/dev/api/tracker/trackedEntities.json?ouMode=SELECTED&includeDeleted=false&dataElementIdScheme=UID&eventIdScheme=UID&orgUnitIdScheme=UID&idScheme=UID&attachment=trackedEntities.json&paging=false&totalPages=false&orgUnits=ImspTQPwCqd&trackedEntityType=bVkFYAvoUCP'
         const link = locationAssign(url)
-        expect(link.download).toEqual('trackedEntities.json')
+        expect(link.download).toEqual('trackedEntities')
     })
     it('should create url with CSV', () => {
         const url =
             'https://debug.dhis2.org/dev/api/tracker/trackedEntities.csv?ouMode=SELECTED&includeDeleted=false&dataElementIdScheme=UID&eventIdScheme=UID&orgUnitIdScheme=UID&idScheme=UID&attachment=trackedEntities.csv&paging=false&totalPages=false&orgUnits=ImspTQPwCqd&program=lxAQ7Zs9VYR'
         const link = locationAssign(url)
-        expect(link.download).toEqual('trackedEntities.csv')
+        expect(link.download).toEqual('trackedEntities')
     })
 
     it('should create url with events zip', () => {
         const url =
             'https://debug.dhis2.org/dev/api/tracker/events.json.zip?links=false&paging=false&totalPages=false&orgUnit=fwH9ipvXde9&program=VBqh0ynB2wv&includeDeleted=false&dataElementIdScheme=UID&orgUnitIdScheme=UID&idScheme=UID&attachment=events.json.zip&occurredAfter=2023-12-12&occurredBefore=2024-03-12&ouMode=CHILDREN&format=json'
         const link = locationAssign(url)
-        expect(link.download).toEqual('events.json.zip')
+        expect(link.download).toEqual('events')
     })
 
     it('should create url with events gzip', () => {
         const url =
             'https://debug.dhis2.org/dev/api/tracker/events.json.gz?links=false&paging=false&totalPages=false&orgUnit=ImspTQPwCqd&program=lxAQ7Zs9VYR&includeDeleted=false&dataElementIdScheme=UID&orgUnitIdScheme=UID&idScheme=UID&attachment=events.json.gz&occurredAfter=2023-12-12&occurredBefore=2024-03-12&ouMode=SELECTED&format=json'
         const link = locationAssign(url)
-        expect(link.download).toEqual('events.json.gz')
+        expect(link.download).toEqual('events')
     })
     it('should work with relative URLs when bundled in DHIS2', () => {
         Object.defineProperty(global.document, 'baseURI', {
@@ -46,7 +46,7 @@ describe('locationAssign', () => {
         const url =
             '../api/tracker/trackedEntities.json?ouMode=SELECTED&includeDeleted=false&dataElementIdScheme=UID&eventIdScheme=UID&orgUnitIdScheme=UID&idScheme=UID&attachment=trackedEntities.json&paging=false&totalPages=false&orgUnits=ImspTQPwCqd&program=lxAQ7Zs9VYR'
         const link = locationAssign(url)
-        expect(link.download).toEqual('trackedEntities.json')
+        expect(link.download).toEqual('trackedEntities')
     })
     it('should work with relative URLs when bundled in DHIS2 for zip', () => {
         Object.defineProperty(global.document, 'baseURI', {
@@ -55,6 +55,6 @@ describe('locationAssign', () => {
         const url =
             '../api/tracker/events.json.zip?links=false&paging=false&totalPages=false&orgUnit=ImspTQPwCqd&program=lxAQ7Zs9VYR&includeDeleted=false&dataElementIdScheme=UID&orgUnitIdScheme=UID&idScheme=UID&attachment=events.json.zip&occurredAfter=2023-12-12&occurredBefore=2024-03-12&ouMode=SELECTED&format=json'
         const link = locationAssign(url)
-        expect(link.download).toEqual('events.json.zip')
+        expect(link.download).toEqual('events')
     })
 })


### PR DESCRIPTION
This allows downloading exported `json` files - right now, it just opens in a new window since the API no longer returns the `content-disposition` header for JSON uncompressed. To fix that, we're using the [download](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#download) property of an anchor to trigger a download in the browser. Since the download is triggered programatically, rather than through a link element, we have to create the button in JS and trigger it, similar to this [solution](https://stackoverflow.com/a/49917066). 

Testing this solution needs to happen on the same origin, so it won't work on netlify. You need to build the app and install in an instance, then it works.  
fixes [DHIS2-16988](https://dhis2.atlassian.net/browse/DHIS2-16988)

[DHIS2-16988]: https://dhis2.atlassian.net/browse/DHIS2-16988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

ps: I had a solution [here](https://github.com/dhis2/import-export-app/pull/2015) that creates a longer file name containing other info related to the export, but canned it for now as we didn't agree whether we should do this or not.