### PR TITLE
fix: include event programs for export [DHIS2-17672]

### DIFF
--- a/src/components/Inputs/ProgramPicker.js
+++ b/src/components/Inputs/ProgramPicker.js
@@ -12,7 +12,8 @@ const LISTNAME = 'selectedPrograms'
 const FILTERLABEL = i18n.t('Filter programs')
 const SELECTEDLABEL = i18n.t('Selected programs')
 const ERRORMESSAGE = i18n.t('Something went wrong when loading the programs!')
-const RESOURCETYPE = resourceTypes.PROGRAM
+const PROGRAM_RESOURCE_TYPE = resourceTypes.PROGRAM
+const PROGRAM_WITH_EVENTS_RESOURCE_TYPE = resourceTypes.PROGRAM_WITH_EVENTS
 
 const SINGLE_PROGRAM_VALIDATOR = (selectedPrograms) =>
     selectedPrograms.length == 0
@@ -22,18 +23,27 @@ const SINGLE_PROGRAM_VALIDATOR = (selectedPrograms) =>
 const SINGLE_EXACT_PROGRAM_VALIDATOR = (selectedPrograms) =>
     !selectedPrograms ? i18n.t('One program must be selected') : undefined
 
-const ProgramPicker = ({ multiSelect, label, show, ...rest }) => {
+const ProgramPicker = ({
+    multiSelect,
+    label,
+    show,
+    includeEvents,
+    ...rest
+}) => {
     const programValidator = multiSelect
         ? SINGLE_PROGRAM_VALIDATOR
         : SINGLE_EXACT_PROGRAM_VALIDATOR
     const validator = composeValidators(hasValue, programValidator)
+    const resourceType = includeEvents
+        ? PROGRAM_WITH_EVENTS_RESOURCE_TYPE
+        : PROGRAM_RESOURCE_TYPE
 
     return (
         show && (
             <div style={{ maxWidth: '480px' }}>
                 <ResourcePickerField
                     name={NAME}
-                    resourceType={RESOURCETYPE}
+                    resourceType={resourceType}
                     errorMessage={ERRORMESSAGE}
                     listName={LISTNAME}
                     label={label}
@@ -54,9 +64,11 @@ ProgramPicker.defaultProps = {
     label: LABEL,
     multiSelect: false,
     show: true,
+    includeEvents: false,
 }
 
 ProgramPicker.propTypes = {
+    includeEvents: PropTypes.bool,
     label: PropTypes.string,
     multiSelect: PropTypes.bool,
     show: PropTypes.bool,

--- a/src/components/Inputs/__tests__/ProgramPicker.test.js
+++ b/src/components/Inputs/__tests__/ProgramPicker.test.js
@@ -1,0 +1,41 @@
+import { ReactFinalForm } from '@dhis2/ui'
+import React from 'react'
+import { render } from '@testing-library/react'
+import '@testing-library/jest-dom/extend-expect.js'
+import { useDataQuery } from '@dhis2/app-runtime'
+import { ProgramPicker } from '../ProgramPicker.js'
+import {
+    programQuery,
+    programWithEventsQuery,
+} from '../../ResourcePicker/queries.js'
+
+jest.mock('@dhis2/app-runtime', () => ({
+    ...jest.requireActual('@dhis2/app-runtime'),
+    // eslint-disable-next-line no-unused-vars
+    useDataQuery: jest.fn((query, options) => ({ refetch: () => {} })),
+}))
+
+const renderWithFormWrapper = (children) =>
+    render(
+        <ReactFinalForm.Form onSubmit={() => {}}>
+            {() => <form>{children}</form>}
+        </ReactFinalForm.Form>
+    )
+
+describe('ProgramPicker', () => {
+    test('it invokes useDataQuery with programs query by default', () => {
+        renderWithFormWrapper(<ProgramPicker />)
+        expect(useDataQuery).toHaveBeenCalledWith(
+            programQuery,
+            expect.anything()
+        )
+    })
+
+    test('it invokes useDataQuery with programs and events query if includeEvents is true', () => {
+        renderWithFormWrapper(<ProgramPicker includeEvents />)
+        expect(useDataQuery).toHaveBeenCalledWith(
+            programWithEventsQuery,
+            expect.anything()
+        )
+    })
+})

--- a/src/components/ResourcePicker/ResourcePicker.js
+++ b/src/components/ResourcePicker/ResourcePicker.js
@@ -15,6 +15,7 @@ import {
     TETypeQuery,
     userQuery,
     geojsonAttributesQuery,
+    programWithEventsQuery,
 } from './queries.js'
 import styles from './ResourcePicker.module.css'
 import { resourceTypes } from './resourceTypes.js'
@@ -26,6 +27,8 @@ const resourceToQuery = (resourceType) => {
         return { resourceName: 'dataSets', query: dataSetQuery }
     } else if (resourceType == resourceTypes.PROGRAM) {
         return { resourceName: 'programs', query: programQuery }
+    } else if (resourceType == resourceTypes.PROGRAM_WITH_EVENTS) {
+        return { resourceName: 'programs', query: programWithEventsQuery }
     } else if (resourceType == resourceTypes.TETYPE) {
         return { resourceName: 'trackedEntityTypes', query: TETypeQuery }
     } else if (resourceType == resourceTypes.USER) {

--- a/src/components/ResourcePicker/queries.js
+++ b/src/components/ResourcePicker/queries.js
@@ -19,6 +19,16 @@ const programQuery = {
     },
 }
 
+const programWithEventsQuery = {
+    programs: {
+        resource: 'programs',
+        params: {
+            fields: 'id,displayName',
+            paging: 'false',
+        },
+    },
+}
+
 const TETypeQuery = {
     trackedEntityTypes: {
         resource: 'trackedEntityTypes',
@@ -56,6 +66,7 @@ const geojsonAttributesQuery = {
 export {
     dataSetQuery,
     programQuery,
+    programWithEventsQuery,
     TETypeQuery,
     userQuery,
     geojsonAttributesQuery,

--- a/src/components/ResourcePicker/resourceTypes.js
+++ b/src/components/ResourcePicker/resourceTypes.js
@@ -4,6 +4,7 @@ const resourceTypes = {
     TETYPE: 3,
     USER: 4,
     GEOJSON_ATTRIBUTE: 5,
+    PROGRAM_WITH_EVENTS: 6,
 }
 
 export { resourceTypes }

--- a/src/pages/EventExport/EventExport.js
+++ b/src/pages/EventExport/EventExport.js
@@ -94,7 +94,7 @@ const EventExport = () => {
                         <BasicOptions>
                             <OrgUnitTree multiSelect={false} />
                             <Inclusion />
-                            <ProgramPicker autoSelectFirst />
+                            <ProgramPicker autoSelectFirst includeEvents />
                             <ProgramStages
                                 selectedProgram={values.selectedPrograms}
                                 form={form}


### PR DESCRIPTION
See https://dhis2.atlassian.net/jira/software/c/projects/DHIS2/issues/DHIS2-17672

This PR fixes an issue whereby the programs query had been amended to filter out WITHOUT_REGISTRATION (event) programs, which is relevant for the Tracked Entity Export page, but not for the Event export page.

Due to the structure of the existing code, I opted to just add an additional query (without filters) and look up the appropriate within <ProgramPicker> based on a new `includeEvents` parameter.

### Automated tests
I've added a test for <ProgramPicker> to check that useDataQuery is called with the right query based on the `includeEvents` parameter. There is little test coverage in this app, currently; I think the test for this change could be written better, but it requires a bunch more setup, like setting up a query provider. 

### Manual tests

**Event export page:**
<img width="760" alt="image" src="https://github.com/dhis2/import-export-app/assets/18490902/df648436-12d3-412d-810c-87dbe269c0bf">
_note: `Antenatal care visit` which is an event program is shown_

**Tracked entity export page:**
<img width="811" alt="image" src="https://github.com/dhis2/import-export-app/assets/18490902/06cca5dc-0859-4b7b-95e7-70188c87be5e">

_note: `Antenatal care visit` which is an event program is NOT shown_