### PR TITLE
fix: run GML import async and track it under the METADATA_IMPORT job [DHIS2-21758]

### DIFF
--- a/src/hooks/useTasks.js
+++ b/src/hooks/useTasks.js
@@ -30,6 +30,14 @@ const trackerSummaryQuery = {
     },
 }
 
+// The GML geometry import (POST /api/metadata/gml) is executed by the backend as a
+// METADATA_IMPORT job, so its progress events and summary are published under the
+// METADATA_IMPORT notifier category rather than GML_IMPORT. Translate the UI import
+// category to the backend notifier category when polling, while keeping GML_IMPORT as
+// the UI category used for grouping, filtering and job recreation. [DHIS2-21758]
+const toNotifierCategory = (importType) =>
+    importType === 'GML_IMPORT' ? 'METADATA_IMPORT' : importType
+
 const defaultTasks = {
     data: {},
     event: {},
@@ -60,7 +68,7 @@ const createFetchEvents =
 
             const response = await engine.query(query, {
                 variables: {
-                    type: task.importType,
+                    type: toNotifierCategory(task.importType),
                     taskId: task.id,
                 },
             })
@@ -122,7 +130,7 @@ const createFetchSummary = (engine, setTasks) => async (type, id, task) => {
 
     const response = await engine.query(query, {
         variables: {
-            type: task.importType,
+            type: toNotifierCategory(task.importType),
             taskId: task.id,
         },
     })

--- a/src/pages/GeometryImport/gml-helper.js
+++ b/src/pages/GeometryImport/gml-helper.js
@@ -11,7 +11,7 @@ const onImport =
         // send xhr
         const apiBaseUrl = `${baseUrl}/api/`
         const endpoint = 'metadata/gml.json'
-        const params = `dryRun=${dryRun}`
+        const params = `dryRun=${dryRun}&async=${isAsync}`
         const url = `${apiBaseUrl}${endpoint}?${params}`
 
         try {


### PR DESCRIPTION
## Jira
[DHIS2-21758](https://dhis2.atlassian.net/browse/DHIS2-21758) — *Import/export app UI crash / hang when GML is imported*

## Symptom
Starting an org-unit-geometry **GML** import shows "Job started." and then hangs — no progress, no summary — even when the backend import actually succeeds.

## Root cause (two issues on the GML path)
1. **The request was never made async.** `gml-helper.js` passed `isAsync: true` to `uploadFile` but left `async` **out of the request URL** (`params = \`dryRun=${dryRun}\``). So the backend ran the import **synchronously** and returned the report inline with no job `id`. `uploadFile`, told it was async, then stored the task with `id: undefined, completed: false` and waited for a job that never existed — hence the perpetual "Job started" hang. (The metadata and geojson helpers correctly include `async=${isAsync}` in the URL.)
2. **Wrong notifier category.** Once made async, `POST /api/metadata/gml` runs as a **`METADATA_IMPORT`** job (there is a declared-but-unused `GML_IMPORT` job type). The app polled `system/tasks/GML_IMPORT/<id>` / `taskSummaries/GML_IMPORT/<id>`, which return nothing, so progress/summary would still never appear.

## Fix
- `gml-helper.js`: add `async=${isAsync}` to the request params so a real async job is created and its `id` is returned.
- `useTasks.js`: map the GML task's poll category `GML_IMPORT → METADATA_IMPORT` (backend job type) for the event/summary queries only. `GML_IMPORT` stays as the UI category, so job grouping, the filter chips and "Recreate job" (`/import/gml`) are unchanged.

## Verified against play/dev (2.44) and dev-2-43 (2.43)
With an org unit whose code matches the GML feature:
- New async call `POST /api/metadata/gml.json?dryRun=false&async=true` → `200`, returns a job `id` with `jobType: METADATA_IMPORT`.
- Polling `system/tasks/METADATA_IMPORT/<id>` → streams progress → `"Import complete with status OK … 1 updated"`, `completed: true`.
- Old code path reproduced the hang (sync response treated as async job).

Note: a `409`/`E5001` ("No matching object for reference") on this endpoint is expected and correct when no org unit matches the GML feature's uid/code/name — it is not part of this bug.

AI Assisted

[DHIS2-21758]: https://dhis2.atlassian.net/browse/DHIS2-21758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ