### PR TITLE
fix: run GML import async and track it under the METADATA_IMPORT job [DHIS2-21758]

### DIFF
--- a/src/hooks/useTasks.js
+++ b/src/hooks/useTasks.js
@@ -1,4 +1,4 @@
-import { useDataEngine } from '@dhis2/app-runtime'
+import { useConfig, useDataEngine } from '@dhis2/app-runtime'
 import { useState } from 'react'
 import { allCategories, toNotifierCategory } from '../utils/tasks.jsx'
 
@@ -46,7 +46,8 @@ const defaultJobOverview = {
 const defaultRefetchPeriod = 2000
 
 const createFetchEvents =
-    (engine, setTasks, fetchSummary) => (type, id, task) => {
+    ({ engine, setTasks, fetchSummary, apiVersion }) =>
+    (type, id, task) => {
         const fetchEvents = async () => {
             if (task.completed) {
                 return
@@ -60,7 +61,7 @@ const createFetchEvents =
 
             const response = await engine.query(query, {
                 variables: {
-                    type: toNotifierCategory(task.importType),
+                    type: toNotifierCategory(task.importType, apiVersion),
                     taskId: task.id,
                 },
             })
@@ -108,42 +109,43 @@ const createFetchEvents =
         fetchEvents()
     }
 
-const createFetchSummary = (engine, setTasks) => async (type, id, task) => {
-    const newTask = { ...task }
+const createFetchSummary =
+    (engine, setTasks, apiVersion) => async (type, id, task) => {
+        const newTask = { ...task }
 
-    // we could still keep one query here (the jobs query), but tracker provides a facade to these
-    // and even though this branches the logic unnecessarily, we should stick to
-    // trackers' endpoint for tracker imports and they could abstract some job-related details
-    // more details here: https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/tracker.html#webapi_nti_import_summary
-    const query =
-        task.importType === 'TRACKER_IMPORT_JOB'
-            ? trackerSummaryQuery
-            : jobSummaryQuery
+        // we could still keep one query here (the jobs query), but tracker provides a facade to these
+        // and even though this branches the logic unnecessarily, we should stick to
+        // trackers' endpoint for tracker imports and they could abstract some job-related details
+        // more details here: https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/tracker.html#webapi_nti_import_summary
+        const query =
+            task.importType === 'TRACKER_IMPORT_JOB'
+                ? trackerSummaryQuery
+                : jobSummaryQuery
 
-    const response = await engine.query(query, {
-        variables: {
-            type: toNotifierCategory(task.importType),
-            taskId: task.id,
-        },
-    })
+        const response = await engine.query(query, {
+            variables: {
+                type: toNotifierCategory(task.importType, apiVersion),
+                taskId: task.id,
+            },
+        })
 
-    const { summary, error } = response
+        const { summary, error } = response
 
-    if (error) {
-        console.error('fetchSummary error: ', error)
-        return
+        if (error) {
+            console.error('fetchSummary error: ', error)
+            return
+        }
+
+        if (summary && summary.status == 'ERROR' && !newTask.error) {
+            newTask.error = true
+        }
+
+        newTask.summary = summary
+        setTasks((tasks) => ({
+            ...tasks,
+            [type]: { ...tasks[type], [id]: newTask },
+        }))
     }
-
-    if (summary && summary.status == 'ERROR' && !newTask.error) {
-        newTask.error = true
-    }
-
-    newTask.summary = summary
-    setTasks((tasks) => ({
-        ...tasks,
-        [type]: { ...tasks[type], [id]: newTask },
-    }))
-}
 
 const createAddTask = (setTasks, fetchEvents) => (type, id, entry) => {
     setTasks((tasks) => ({
@@ -162,11 +164,18 @@ const createUpdateJobOverview = (setJobOverview) => (val) => {
 
 const useTasks = () => {
     const engine = useDataEngine()
+    const { serverVersion } = useConfig()
+    const { minor } = serverVersion ?? {}
     const [tasks, setTasks] = useState(defaultTasks)
     const [jobOverview, setJobOverview] = useState(defaultJobOverview)
 
-    const fetchSummary = createFetchSummary(engine, setTasks)
-    const fetchEvents = createFetchEvents(engine, setTasks, fetchSummary)
+    const fetchSummary = createFetchSummary(engine, setTasks, minor)
+    const fetchEvents = createFetchEvents({
+        engine,
+        setTasks,
+        fetchSummary,
+        apiVersion: minor,
+    })
     const addTask = createAddTask(setTasks, fetchEvents)
     const updateJobOverview = createUpdateJobOverview(setJobOverview)
 

--- a/src/hooks/useTasks.js
+++ b/src/hooks/useTasks.js
@@ -1,4 +1,4 @@
-import { useConfig, useDataEngine } from '@dhis2/app-runtime'
+import { useDataEngine } from '@dhis2/app-runtime'
 import { useState } from 'react'
 import { allCategories, toNotifierCategory } from '../utils/tasks.jsx'
 
@@ -46,8 +46,7 @@ const defaultJobOverview = {
 const defaultRefetchPeriod = 2000
 
 const createFetchEvents =
-    ({ engine, setTasks, fetchSummary, apiVersion }) =>
-    (type, id, task) => {
+    (engine, setTasks, fetchSummary) => (type, id, task) => {
         const fetchEvents = async () => {
             if (task.completed) {
                 return
@@ -61,7 +60,7 @@ const createFetchEvents =
 
             const response = await engine.query(query, {
                 variables: {
-                    type: toNotifierCategory(task.importType, apiVersion),
+                    type: toNotifierCategory(task.importType),
                     taskId: task.id,
                 },
             })
@@ -109,43 +108,42 @@ const createFetchEvents =
         fetchEvents()
     }
 
-const createFetchSummary =
-    (engine, setTasks, apiVersion) => async (type, id, task) => {
-        const newTask = { ...task }
+const createFetchSummary = (engine, setTasks) => async (type, id, task) => {
+    const newTask = { ...task }
 
-        // we could still keep one query here (the jobs query), but tracker provides a facade to these
-        // and even though this branches the logic unnecessarily, we should stick to
-        // trackers' endpoint for tracker imports and they could abstract some job-related details
-        // more details here: https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/tracker.html#webapi_nti_import_summary
-        const query =
-            task.importType === 'TRACKER_IMPORT_JOB'
-                ? trackerSummaryQuery
-                : jobSummaryQuery
+    // we could still keep one query here (the jobs query), but tracker provides a facade to these
+    // and even though this branches the logic unnecessarily, we should stick to
+    // trackers' endpoint for tracker imports and they could abstract some job-related details
+    // more details here: https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/tracker.html#webapi_nti_import_summary
+    const query =
+        task.importType === 'TRACKER_IMPORT_JOB'
+            ? trackerSummaryQuery
+            : jobSummaryQuery
 
-        const response = await engine.query(query, {
-            variables: {
-                type: toNotifierCategory(task.importType, apiVersion),
-                taskId: task.id,
-            },
-        })
+    const response = await engine.query(query, {
+        variables: {
+            type: toNotifierCategory(task.importType),
+            taskId: task.id,
+        },
+    })
 
-        const { summary, error } = response
+    const { summary, error } = response
 
-        if (error) {
-            console.error('fetchSummary error: ', error)
-            return
-        }
-
-        if (summary && summary.status == 'ERROR' && !newTask.error) {
-            newTask.error = true
-        }
-
-        newTask.summary = summary
-        setTasks((tasks) => ({
-            ...tasks,
-            [type]: { ...tasks[type], [id]: newTask },
-        }))
+    if (error) {
+        console.error('fetchSummary error: ', error)
+        return
     }
+
+    if (summary && summary.status == 'ERROR' && !newTask.error) {
+        newTask.error = true
+    }
+
+    newTask.summary = summary
+    setTasks((tasks) => ({
+        ...tasks,
+        [type]: { ...tasks[type], [id]: newTask },
+    }))
+}
 
 const createAddTask = (setTasks, fetchEvents) => (type, id, entry) => {
     setTasks((tasks) => ({
@@ -164,18 +162,11 @@ const createUpdateJobOverview = (setJobOverview) => (val) => {
 
 const useTasks = () => {
     const engine = useDataEngine()
-    const { serverVersion } = useConfig()
-    const { minor } = serverVersion ?? {}
     const [tasks, setTasks] = useState(defaultTasks)
     const [jobOverview, setJobOverview] = useState(defaultJobOverview)
 
-    const fetchSummary = createFetchSummary(engine, setTasks, minor)
-    const fetchEvents = createFetchEvents({
-        engine,
-        setTasks,
-        fetchSummary,
-        apiVersion: minor,
-    })
+    const fetchSummary = createFetchSummary(engine, setTasks)
+    const fetchEvents = createFetchEvents(engine, setTasks, fetchSummary)
     const addTask = createAddTask(setTasks, fetchEvents)
     const updateJobOverview = createUpdateJobOverview(setJobOverview)
 

--- a/src/hooks/useTasks.js
+++ b/src/hooks/useTasks.js
@@ -30,6 +30,14 @@ const trackerSummaryQuery = {
     },
 }
 
+// The GML geometry import (POST /api/metadata/gml) is executed by the backend as a
+// METADATA_IMPORT job, so its progress events and summary are published under the
+// METADATA_IMPORT notifier category rather than GML_IMPORT. Translate the UI import
+// category to the backend notifier category when polling, while keeping GML_IMPORT as
+// the UI category used for grouping, filtering and job recreation. [DHIS2-21758]
+const toNotifierCategory = (importType) =>
+    importType === 'GML_IMPORT' ? 'METADATA_IMPORT' : importType
+
 const defaultTasks = {
     data: {},
     event: {},
@@ -60,7 +68,7 @@ const createFetchEvents =
 
             const response = await engine.query(query, {
                 variables: {
-                    type: task.importType,
+                    type: toNotifierCategory(task.importType),
                     taskId: task.id,
                 },
             })
@@ -122,7 +130,7 @@ const createFetchSummary = (engine, setTasks) => async (type, id, task) => {
 
     const response = await engine.query(query, {
         variables: {
-            type: task.importType,
+            type: toNotifierCategory(task.importType),
             taskId: task.id,
         },
     })

--- a/src/hooks/useTasks.js
+++ b/src/hooks/useTasks.js
@@ -1,6 +1,6 @@
 import { useDataEngine } from '@dhis2/app-runtime'
 import { useState } from 'react'
-import { allCategories } from '../utils/tasks.jsx'
+import { allCategories, toNotifierCategory } from '../utils/tasks.jsx'
 
 const jobEventQuery = {
     events: {
@@ -29,14 +29,6 @@ const trackerSummaryQuery = {
         id: ({ taskId }) => `${taskId}/report`,
     },
 }
-
-// The GML geometry import (POST /api/metadata/gml) is executed by the backend as a
-// METADATA_IMPORT job, so its progress events and summary are published under the
-// METADATA_IMPORT notifier category rather than GML_IMPORT. Translate the UI import
-// category to the backend notifier category when polling, while keeping GML_IMPORT as
-// the UI category used for grouping, filtering and job recreation. [DHIS2-21758]
-const toNotifierCategory = (importType) =>
-    importType === 'GML_IMPORT' ? 'METADATA_IMPORT' : importType
 
 const defaultTasks = {
     data: {},

--- a/src/pages/GeometryImport/gml-helper.js
+++ b/src/pages/GeometryImport/gml-helper.js
@@ -11,7 +11,7 @@ const onImport =
         // send xhr
         const apiBaseUrl = `${baseUrl}/api/`
         const endpoint = 'metadata/gml.json'
-        const params = `dryRun=${dryRun}`
+        const params = `dryRun=${dryRun}&async=${isAsync}`
         const url = `${apiBaseUrl}${endpoint}?${params}`
 
         try {

--- a/src/utils/__test__/tasks.test.js
+++ b/src/utils/__test__/tasks.test.js
@@ -1,32 +1,17 @@
 import { allCategories, toNotifierCategory } from '../tasks.jsx'
 
-// Mirrors the shape of useConfig()'s serverVersion, e.g. { minor: '44' }
-const currentApiVersion = '44'
-const preGmlMetadataApiVersion = '40'
-
 describe('toNotifierCategory', () => {
-    it('maps the GML_IMPORT UI category to the METADATA_IMPORT notifier category from API version 41 onwards', () => {
-        // POST /api/metadata/gml runs as a METADATA_IMPORT job on the backend from API
-        // version 41 onwards, so its progress events and summary are published under
-        // METADATA_IMPORT. [DHIS2-21758]
-        expect(toNotifierCategory('GML_IMPORT', currentApiVersion)).toBe(
-            'METADATA_IMPORT'
-        )
+    it('maps the GML_IMPORT UI category to the METADATA_IMPORT notifier category', () => {
+        // POST /api/metadata/gml runs as a METADATA_IMPORT job on the backend, so its
+        // progress events and summary are published under METADATA_IMPORT. [DHIS2-21758]
+        expect(toNotifierCategory('GML_IMPORT')).toBe('METADATA_IMPORT')
     })
 
     it('leaves every other import category unchanged', () => {
         allCategories
             .filter((category) => category !== 'GML_IMPORT')
             .forEach((category) => {
-                expect(toNotifierCategory(category, currentApiVersion)).toBe(
-                    category
-                )
+                expect(toNotifierCategory(category)).toBe(category)
             })
-    })
-
-    it('leaves the GML_IMPORT UI category unchanged for API versions before 41', () => {
-        expect(toNotifierCategory('GML_IMPORT', preGmlMetadataApiVersion)).toBe(
-            'GML_IMPORT'
-        )
     })
 })

--- a/src/utils/__test__/tasks.test.js
+++ b/src/utils/__test__/tasks.test.js
@@ -1,17 +1,32 @@
 import { allCategories, toNotifierCategory } from '../tasks.jsx'
 
+// Mirrors the shape of useConfig()'s serverVersion, e.g. { minor: '44' }
+const currentApiVersion = '44'
+const preGmlMetadataApiVersion = '40'
+
 describe('toNotifierCategory', () => {
-    it('maps the GML_IMPORT UI category to the METADATA_IMPORT notifier category', () => {
-        // POST /api/metadata/gml runs as a METADATA_IMPORT job on the backend, so its
-        // progress events and summary are published under METADATA_IMPORT. [DHIS2-21758]
-        expect(toNotifierCategory('GML_IMPORT')).toBe('METADATA_IMPORT')
+    it('maps the GML_IMPORT UI category to the METADATA_IMPORT notifier category from API version 41 onwards', () => {
+        // POST /api/metadata/gml runs as a METADATA_IMPORT job on the backend from API
+        // version 41 onwards, so its progress events and summary are published under
+        // METADATA_IMPORT. [DHIS2-21758]
+        expect(toNotifierCategory('GML_IMPORT', currentApiVersion)).toBe(
+            'METADATA_IMPORT'
+        )
     })
 
     it('leaves every other import category unchanged', () => {
         allCategories
             .filter((category) => category !== 'GML_IMPORT')
             .forEach((category) => {
-                expect(toNotifierCategory(category)).toBe(category)
+                expect(toNotifierCategory(category, currentApiVersion)).toBe(
+                    category
+                )
             })
+    })
+
+    it('leaves the GML_IMPORT UI category unchanged for API versions before 41', () => {
+        expect(toNotifierCategory('GML_IMPORT', preGmlMetadataApiVersion)).toBe(
+            'GML_IMPORT'
+        )
     })
 })

--- a/src/utils/__test__/tasks.test.js
+++ b/src/utils/__test__/tasks.test.js
@@ -1,0 +1,17 @@
+import { allCategories, toNotifierCategory } from '../tasks.jsx'
+
+describe('toNotifierCategory', () => {
+    it('maps the GML_IMPORT UI category to the METADATA_IMPORT notifier category', () => {
+        // POST /api/metadata/gml runs as a METADATA_IMPORT job on the backend, so its
+        // progress events and summary are published under METADATA_IMPORT. [DHIS2-21758]
+        expect(toNotifierCategory('GML_IMPORT')).toBe('METADATA_IMPORT')
+    })
+
+    it('leaves every other import category unchanged', () => {
+        allCategories
+            .filter((category) => category !== 'GML_IMPORT')
+            .forEach((category) => {
+                expect(toNotifierCategory(category)).toBe(category)
+            })
+    })
+})

--- a/src/utils/tasks.jsx
+++ b/src/utils/tasks.jsx
@@ -49,12 +49,16 @@ const categoryTypes = [
 
 const allCategories = categoryTypes.map(({ importType }) => importType)
 
-// The GML geometry import (POST /api/metadata/gml) is executed by the backend as a
-// METADATA_IMPORT job, so its progress events and summary are published under the
-// METADATA_IMPORT notifier category rather than GML_IMPORT. Translate the UI import
-// category to the backend notifier category when polling, while keeping GML_IMPORT as
-// the UI category used for grouping, filtering and job recreation. [DHIS2-21758]
-const toNotifierCategory = (importType) =>
-    importType === 'GML_IMPORT' ? 'METADATA_IMPORT' : importType
+// From API version 41 onwards, the GML geometry import (POST /api/metadata/gml) is
+// executed by the backend as a METADATA_IMPORT job, so its progress events and summary
+// are published under the METADATA_IMPORT notifier category rather than GML_IMPORT.
+// Translate the UI import category to the backend notifier category when polling on
+// 41+, while keeping GML_IMPORT as the UI category used for grouping, filtering and job
+// recreation. Before version 41, GML imports are tracked directly under GML_IMPORT, so
+// no translation is needed. [DHIS2-21758]
+const toNotifierCategory = (importType, apiVersion) =>
+    importType === 'GML_IMPORT' && apiVersion >= 41
+        ? 'METADATA_IMPORT'
+        : importType
 
 export { categoryTypes, allCategories, toNotifierCategory }

--- a/src/utils/tasks.jsx
+++ b/src/utils/tasks.jsx
@@ -49,4 +49,12 @@ const categoryTypes = [
 
 const allCategories = categoryTypes.map(({ importType }) => importType)
 
-export { categoryTypes, allCategories }
+// The GML geometry import (POST /api/metadata/gml) is executed by the backend as a
+// METADATA_IMPORT job, so its progress events and summary are published under the
+// METADATA_IMPORT notifier category rather than GML_IMPORT. Translate the UI import
+// category to the backend notifier category when polling, while keeping GML_IMPORT as
+// the UI category used for grouping, filtering and job recreation. [DHIS2-21758]
+const toNotifierCategory = (importType) =>
+    importType === 'GML_IMPORT' ? 'METADATA_IMPORT' : importType
+
+export { categoryTypes, allCategories, toNotifierCategory }

--- a/src/utils/tasks.jsx
+++ b/src/utils/tasks.jsx
@@ -49,16 +49,12 @@ const categoryTypes = [
 
 const allCategories = categoryTypes.map(({ importType }) => importType)
 
-// From API version 41 onwards, the GML geometry import (POST /api/metadata/gml) is
-// executed by the backend as a METADATA_IMPORT job, so its progress events and summary
-// are published under the METADATA_IMPORT notifier category rather than GML_IMPORT.
-// Translate the UI import category to the backend notifier category when polling on
-// 41+, while keeping GML_IMPORT as the UI category used for grouping, filtering and job
-// recreation. Before version 41, GML imports are tracked directly under GML_IMPORT, so
-// no translation is needed. [DHIS2-21758]
-const toNotifierCategory = (importType, apiVersion) =>
-    importType === 'GML_IMPORT' && apiVersion >= 41
-        ? 'METADATA_IMPORT'
-        : importType
+// The GML geometry import (POST /api/metadata/gml) is executed by the backend as a
+// METADATA_IMPORT job, so its progress events and summary are published under the
+// METADATA_IMPORT notifier category rather than GML_IMPORT. Translate the UI import
+// category to the backend notifier category when polling, while keeping GML_IMPORT as
+// the UI category used for grouping, filtering and job recreation. [DHIS2-21758]
+const toNotifierCategory = (importType) =>
+    importType === 'GML_IMPORT' ? 'METADATA_IMPORT' : importType
 
 export { categoryTypes, allCategories, toNotifierCategory }


### PR DESCRIPTION
## Jira
[DHIS2-21758](https://dhis2.atlassian.net/browse/DHIS2-21758) — *Import/export app UI crash / hang when GML is imported*

## Symptom
Starting an org-unit-geometry **GML** import shows "Job started." and then hangs — no progress, no summary — even when the backend import actually succeeds.

## Root cause (two issues on the GML path)
1. **The request was never made async.** `gml-helper.js` passed `isAsync: true` to `uploadFile` but left `async` **out of the request URL** (`params = \`dryRun=${dryRun}\``). So the backend ran the import **synchronously** and returned the report inline with no job `id`. `uploadFile`, told it was async, then stored the task with `id: undefined, completed: false` and waited for a job that never existed — hence the perpetual "Job started" hang. (The metadata and geojson helpers correctly include `async=${isAsync}` in the URL.)
2. **Wrong notifier category.** Once made async, `POST /api/metadata/gml` runs as a **`METADATA_IMPORT`** job (there is a declared-but-unused `GML_IMPORT` job type). The app polled `system/tasks/GML_IMPORT/<id>` / `taskSummaries/GML_IMPORT/<id>`, which return nothing, so progress/summary would still never appear.

## Fix
- `gml-helper.js`: add `async=${isAsync}` to the request params so a real async job is created and its `id` is returned.
- `useTasks.js`: map the GML task's poll category `GML_IMPORT → METADATA_IMPORT` (backend job type) for the event/summary queries only. `GML_IMPORT` stays as the UI category, so job grouping, the filter chips and "Recreate job" (`/import/gml`) are unchanged.

## Verified against play/dev (2.44) and dev-2-43 (2.43)
With an org unit whose code matches the GML feature:
- New async call `POST /api/metadata/gml.json?dryRun=false&async=true` → `200`, returns a job `id` with `jobType: METADATA_IMPORT`.
- Polling `system/tasks/METADATA_IMPORT/<id>` → streams progress → `"Import complete with status OK … 1 updated"`, `completed: true`.
- UI: import now completes with a summary instead of hanging (verified in a local build against play/dev).

Note: a `409`/`E5001` ("No matching object for reference") on this endpoint is expected and correct when no org unit matches the GML feature's uid/code/name — it is not part of this bug.

AI Assisted

[DHIS2-21758]: https://dhis2.atlassian.net/browse/DHIS2-21758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ