### PR TITLE
fix: filter out objects with embeddedObject true [DHIS2-21770]

### DIFF
--- a/src/components/Schemas/Schemas.jsx
+++ b/src/components/Schemas/Schemas.jsx
@@ -17,7 +17,13 @@ const schemaQuery = {
     schemas: {
         resource: 'schemas',
         params: {
-            fields: ['metadata', 'collectionName', 'displayName', 'klass'],
+            fields: [
+                'metadata',
+                'collectionName',
+                'displayName',
+                'klass',
+                'embeddedObject',
+            ],
         },
     },
 }

--- a/src/components/Schemas/helper.js
+++ b/src/components/Schemas/helper.js
@@ -150,7 +150,9 @@ const getGroupOrder = (schemas) => {
 const filterOutExcludedSchemas = (excludedSchemas, schemas) =>
     schemas.filter(
         (schema) =>
-            schema.metadata && !excludedSchemas.has(schema.collectionName)
+            schema.metadata &&
+            !schema.embeddedObject &&
+            !excludedSchemas.has(schema.collectionName)
     )
 
 const groupName = (klass) => {


### PR DESCRIPTION
Fiter out elements with embeddedObject = true. Currently only Map View should be excluded from the list.

[DHIS2-21770](https://dhis2.atlassian.net/browse/DHIS2-21770)

_Map View_
<img width="1176" height="858" alt="image" src="https://github.com/user-attachments/assets/336ee2ac-f27e-4c6c-bba0-46277e4aea1f" />


[DHIS2-21770]: https://dhis2.atlassian.net/browse/DHIS2-21770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ